### PR TITLE
Compare ctHashes during permit validation without metadata

### DIFF
--- a/contracts/FHERC20.sol
+++ b/contracts/FHERC20.sol
@@ -498,7 +498,7 @@ abstract contract FHERC20 is IFHERC20, IFHERC20Errors, Context, EIP712, Nonces {
         if (msg.sender != permit.spender) {
             revert FHERC20EncTransferFromSpenderMismatch(msg.sender, permit.spender);
         }
-        if (inHash != permit.value_hash) {
+        if (!_ctHashesEqualExcludingMetadata(inHash, permit.value_hash)) {
             revert FHERC20EncTransferFromValueHashMismatch(inHash, permit.value_hash);
         }
 
@@ -519,5 +519,14 @@ abstract contract FHERC20 is IFHERC20, IFHERC20Errors, Context, EIP712, Nonces {
         if (signer != permit.owner) {
             revert ERC2612InvalidSigner(signer, permit.owner);
         }
+    }
+
+    /**
+     * @dev Compares ctHashes excluding the appended metadata.
+     * XORs the hashes, and checks if the non-matching bytes is less than the metadata length.
+     * Metadata being excluded: securityZone, utype, trivially encrypted flag.
+     */
+    function _ctHashesEqualExcludingMetadata(uint256 lhs, uint256 rhs) internal view returns (bool) {
+        return (lhs ^ rhs) <= type(uint16).max;
     }
 }

--- a/test/FHERC20.test.ts
+++ b/test/FHERC20.test.ts
@@ -500,7 +500,7 @@ describe("FHERC20", function () {
         signer: bob,
         owner: bob.address,
         spender: alice.address,
-        valueHash: encTransferInput.ctHash + 1n,
+        valueHash: encTransferInput.ctHash + 1000000000n,
       });
 
       // Expect revert


### PR DESCRIPTION
Eliminates need to manually append metadata to ctHash clientside before contract call.