### PR TITLE
ERC20Confidential Extension

### DIFF
--- a/contracts/extensions/ERC20Confidential.sol
+++ b/contracts/extensions/ERC20Confidential.sol
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import { FHE, euint64, InEuint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+import { IERC20Confidential } from "./IERC20Confidential.sol";
+import { ERC20ConfidentialIndicator } from "./ERC20ConfidentialIndicator.sol";
+
+/**
+ * @title ERC20Confidential
+ * @dev Extension of ERC20 to support confidential balance and transfers
+ *
+ * This contract provides dual-balance functionality:
+ * - Standard ERC20 balances and transfers (public)
+ * - Confidential balances and transfers (encrypted)
+ * - Wrap/unwrap functionality to convert between public and confidential tokens
+ *
+ * The confidential pool is represented by a fixed address where wrapped tokens are stored.
+ */
+abstract contract ERC20Confidential is ERC20, IERC20Confidential {
+    // Fixed address representing the confidential token pool (using confidential tag)
+    address private constant CONFIDENTIAL_POOL = address(0x1011000000000000000000000000000000000000);
+
+    // Mapping for confidential balances (encrypted)
+    mapping(address => euint64) private _confidentialBalances;
+
+    // Operator system for confidentialTransferFrom
+    mapping(address => mapping(address => uint48)) private _operators;
+
+    // Indicator token for showing confidential activity
+    ERC20ConfidentialIndicator public immutable indicatorToken;
+
+    // Unwrap claim system - only one claim per user at a time
+    struct UnwrapClaim {
+        uint256 ctHash;
+        uint64 requestedAmount;
+        uint64 decryptedAmount;
+        bool decrypted;
+        bool claimed;
+    }
+
+    mapping(address => UnwrapClaim) private _userUnwrapClaims;
+
+    /**
+     * @dev Constructor that deploys the indicator token
+     */
+    constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) {
+        // Deploy the indicator token
+        indicatorToken = new ERC20ConfidentialIndicator(address(this), name_, symbol_);
+    }
+
+    /**
+     * @dev Unauthorized use of encrypted amount.
+     */
+    error ERC20ConfidentialUnauthorizedUseOfEncryptedAmount(euint64 value, address user);
+
+    /**
+     * @dev Unauthorized spender for confidential transfer.
+     */
+    error ERC20ConfidentialUnauthorizedSpender(address holder, address spender);
+
+    /**
+     * @dev Unwrap claim not found.
+     */
+    error UnwrapClaimNotFound();
+
+    /**
+     * @dev Unwrap claim already claimed.
+     */
+    error UnwrapClaimAlreadyClaimed();
+
+    /**
+     * @dev User already has an active unwrap claim.
+     */
+    error UserHasActiveUnwrapClaim();
+
+    /**
+     * @dev Returns the confidential balance of an account (encrypted)
+     */
+    function confidentialBalanceOf(address account) public view virtual override returns (euint64) {
+        return _confidentialBalances[account];
+    }
+
+    /**
+     * @dev Returns true if `spender` is currently an operator for `holder`
+     */
+    function isOperator(address holder, address spender) public view virtual override returns (bool) {
+        return holder == spender || block.timestamp <= _operators[holder][spender];
+    }
+
+    /**
+     * @dev Wrap public tokens to confidential tokens
+     * Transfers tokens from the caller's public balance to the confidential pool
+     */
+    function wrap(uint64 amount) public virtual override {
+        // Transfer tokens from sender to confidential pool
+        _transfer(msg.sender, CONFIDENTIAL_POOL, amount);
+
+        // Update sender's confidential balance
+        _confidentialUpdate(address(0), msg.sender, FHE.asEuint64(amount));
+
+        emit TokensWrapped(msg.sender, amount);
+    }
+
+    /**
+     * @dev Unwrap confidential tokens to public tokens
+     * Burns confidential tokens and creates a claim that can be redeemed after decryption
+     */
+    function unwrap(uint64 amount) public virtual override {
+        // Check if user already has an active unwrap claim
+        UnwrapClaim memory existingClaim = _userUnwrapClaims[msg.sender];
+        if (existingClaim.ctHash != 0 && !existingClaim.claimed) revert UserHasActiveUnwrapClaim();
+
+        // Burn confidential tokens from sender
+        euint64 burned = _confidentialUpdate(msg.sender, address(0), FHE.asEuint64(amount));
+
+        // Call FHE.decrypt to initiate decryption
+        FHE.decrypt(burned);
+
+        // Create unwrap claim
+        _createUnwrapClaim(msg.sender, amount, burned);
+
+        emit TokensUnwrapped(msg.sender, euint64.unwrap(burned));
+    }
+
+    /**
+     * @dev Claim unwrapped tokens after decryption is complete
+     */
+    function claimUnwrapped() public virtual {
+        UnwrapClaim memory claim = _handleUnwrapClaim(msg.sender);
+
+        // Transfer tokens from confidential pool to sender
+        _transfer(CONFIDENTIAL_POOL, msg.sender, claim.decryptedAmount);
+
+        emit UnwrappedTokensClaimed(msg.sender, claim.decryptedAmount);
+    }
+
+    /**
+     * @dev Transfer confidential tokens to another account
+     */
+    function confidentialTransfer(address to, euint64 value) public virtual override returns (euint64 transferred) {
+        if (!FHE.isAllowed(value, msg.sender)) {
+            revert ERC20ConfidentialUnauthorizedUseOfEncryptedAmount(value, msg.sender);
+        }
+        transferred = _confidentialTransfer(msg.sender, to, value);
+    }
+
+    /**
+     * @dev Transfer confidential tokens to another account (with InEuint64 input)
+     */
+    function confidentialTransfer(
+        address to,
+        InEuint64 memory inValue
+    ) public virtual override returns (euint64 transferred) {
+        euint64 value = FHE.asEuint64(inValue);
+        transferred = _confidentialTransfer(msg.sender, to, value);
+    }
+
+    /**
+     * @dev Transfer confidential tokens from one account to another (with operator approval)
+     */
+    function confidentialTransferFrom(
+        address from,
+        address to,
+        euint64 value
+    ) public virtual override returns (euint64 transferred) {
+        if (!FHE.isAllowed(value, msg.sender)) {
+            revert ERC20ConfidentialUnauthorizedUseOfEncryptedAmount(value, msg.sender);
+        }
+        if (!isOperator(from, msg.sender)) {
+            revert ERC20ConfidentialUnauthorizedSpender(from, msg.sender);
+        }
+        transferred = _confidentialTransfer(from, to, value);
+    }
+
+    /**
+     * @dev Transfer confidential tokens from one account to another (with InEuint64 input)
+     */
+    function confidentialTransferFrom(
+        address from,
+        address to,
+        InEuint64 memory inValue
+    ) public virtual override returns (euint64 transferred) {
+        if (!isOperator(from, msg.sender)) {
+            revert ERC20ConfidentialUnauthorizedSpender(from, msg.sender);
+        }
+        euint64 value = FHE.asEuint64(inValue);
+        transferred = _confidentialTransfer(from, to, value);
+    }
+
+    /**
+     * @dev Set an operator for confidential transfers
+     */
+    function setOperator(address operator, uint48 until) public virtual override {
+        _setOperator(msg.sender, operator, until);
+    }
+
+    function _confidentialTransfer(
+        address from,
+        address to,
+        euint64 value
+    ) internal virtual returns (euint64 transferred) {
+        if (from == address(0)) revert ERC20InvalidSender(address(0));
+        if (to == address(0)) revert ERC20InvalidReceiver(address(0));
+        transferred = _confidentialUpdate(from, to, value);
+    }
+
+    /**
+     * @dev Internal function to update confidential balances
+     */
+    function _confidentialUpdate(
+        address from,
+        address to,
+        euint64 value
+    ) internal virtual returns (euint64 transferred) {
+        // If `value` is greater than the user's encBalance, it is replaced with 0
+        // The transaction will succeed, but the amount transferred may be 0
+        // Both `from` and `to` will have their `encBalance` updated in either case to preserve confidentiality
+        //
+        // NOTE: If the function is `_mint`, `from` is the zero address, and does not have an `encBalance` to
+        //       compare against, so this check is skipped.
+        if (from != address(0)) {
+            transferred = FHE.select(value.lte(_confidentialBalances[from]), value, FHE.asEuint64(0));
+        } else {
+            transferred = value;
+        }
+
+        // Only update the balance if the from address is not the zero address (not minting)
+        if (from != address(0)) {
+            _confidentialBalances[from] = FHE.sub(_confidentialBalances[from], transferred);
+        }
+
+        // Only update the balance if the to address is not the zero address (not burning)
+        if (to != address(0)) {
+            _confidentialBalances[to] = FHE.add(_confidentialBalances[to], transferred);
+        }
+
+        // Update CoFHE Access Control List (ACL) to allow decrypting / sealing of the new balances
+        if (from != address(0) && euint64.unwrap(_confidentialBalances[from]) != 0) {
+            FHE.allowThis(_confidentialBalances[from]);
+            FHE.allow(_confidentialBalances[from], from);
+            FHE.allow(transferred, from);
+        }
+        if (to != address(0) && euint64.unwrap(_confidentialBalances[to]) != 0) {
+            FHE.allowThis(_confidentialBalances[to]);
+            FHE.allow(_confidentialBalances[to], to);
+            FHE.allow(transferred, to);
+        }
+
+        // Allow the caller to decrypt the transferred amount
+        FHE.allow(transferred, msg.sender);
+
+        // Emit Transfer event from indicator token
+        indicatorToken.emitConfidentialTransfer(from, to);
+
+        emit ConfidentialTransfer(from, to, euint64.unwrap(transferred));
+    }
+
+    /**
+     * @dev Internal function to set an operator
+     */
+    function _setOperator(address holder, address operator, uint48 until) internal virtual {
+        _operators[holder][operator] = until;
+        emit OperatorSet(holder, operator, until);
+    }
+
+    /**
+     * @dev Internal function to create an unwrap claim
+     */
+    function _createUnwrapClaim(address to, uint64 value, euint64 claimable) internal {
+        _userUnwrapClaims[to] = UnwrapClaim({
+            ctHash: euint64.unwrap(claimable),
+            requestedAmount: value,
+            decryptedAmount: 0,
+            decrypted: false,
+            claimed: false
+        });
+    }
+
+    /**
+     * @dev Internal function to handle a user's unwrap claim
+     */
+    function _handleUnwrapClaim(address user) internal returns (UnwrapClaim memory claim) {
+        claim = _userUnwrapClaims[user];
+
+        // Check that the claim exists and has not been claimed yet
+        if (claim.ctHash == 0) revert UnwrapClaimNotFound();
+        if (claim.claimed) revert UnwrapClaimAlreadyClaimed();
+
+        // Get the decrypted amount (reverts if the amount is not decrypted yet)
+        uint64 amount = SafeCast.toUint64(FHE.getDecryptResult(claim.ctHash));
+
+        // Update the claim
+        claim.decryptedAmount = amount;
+        claim.decrypted = true;
+        claim.claimed = true;
+
+        // Update the claim in storage
+        _userUnwrapClaims[user] = claim;
+    }
+
+    /**
+     * @dev Get the unwrap claim for a user
+     */
+    function getUserUnwrapClaim(address user) public view returns (UnwrapClaim memory) {
+        UnwrapClaim memory claim = _userUnwrapClaims[user];
+        if (claim.ctHash != 0) {
+            (uint256 amount, bool decrypted) = FHE.getDecryptResultSafe(claim.ctHash);
+            claim.decryptedAmount = SafeCast.toUint64(amount);
+            claim.decrypted = decrypted;
+        }
+        return claim;
+    }
+}

--- a/contracts/extensions/ERC20ConfidentialIndicator.sol
+++ b/contracts/extensions/ERC20ConfidentialIndicator.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/**
+ * @title ERC20ConfidentialIndicator
+ * @dev Synthetic token that shows indicated balances for confidential operations
+ *
+ * This token is designed to be added to wallets and block explorers to show
+ * confidential activity without exposing real amounts. All operations revert
+ * except for balance queries and internal updates from the main token.
+ */
+contract ERC20ConfidentialIndicator is ERC20 {
+    address public immutable parent;
+    mapping(address => uint256) private _indicatedBalances;
+
+    /**
+     * @dev Error for ERC20 operations not supported in the indicator token
+     */
+    error ERC20ConfidentialIndicatorNoOp();
+
+    /**
+     * @dev Error for unauthorized access to the indicator token
+     */
+    error ERC20ConfidentialIndicatorOnlyParent();
+
+    /**
+     * @dev Only the main token contract can call certain functions
+     */
+    modifier onlyParent() {
+        if (msg.sender != parent) {
+            revert ERC20ConfidentialIndicatorNoOp();
+        }
+        _;
+    }
+
+    constructor(
+        address parentAddress,
+        string memory parentName,
+        string memory parentSymbol
+    ) ERC20(string.concat("1011000 ", parentName), string.concat("c", parentSymbol)) {
+        parent = parentAddress;
+    }
+
+    /**
+     * @dev Fix number of decimals to 4 for indicated balance display
+     */
+    function decimals() public pure override returns (uint8) {
+        return 4;
+    }
+
+    /**
+     * @dev Returns the indicated balance with confidential tag + tick
+     * This is what wallets and block explorers will see
+     */
+    function balanceOf(address account) public view override returns (uint256) {
+        return 10110000000 + _indicatedBalances[account];
+    }
+
+    function _incrementIndicatedBalance(address account) internal view returns (uint256) {
+        if (_indicatedBalances[account] == 9999) return 9999;
+        if (_indicatedBalances[account] == 0) return 5001;
+        return _indicatedBalances[account] + 1;
+    }
+    function _decrementIndicatedBalance(address account) internal view returns (uint256) {
+        if (_indicatedBalances[account] == 0) return 4999;
+        if (_indicatedBalances[account] == 1) return 1;
+        return _indicatedBalances[account] - 1;
+    }
+
+    function emitConfidentialTransfer(address from, address to) public onlyParent {
+        // Increment indicated balance of to
+        _incrementIndicatedBalance(to);
+
+        // Decrement indicated balance of from
+        _decrementIndicatedBalance(from);
+
+        // Emit ERC20 Transfer event with value 1011000.0001
+        emit Transfer(from, to, 10110000001);
+    }
+
+    // ========== REVERTING FUNCTIONS ==========
+    // All standard ERC20 operations should revert since this is just an indicator
+
+    function transfer(address, uint256) public pure override returns (bool) {
+        revert ERC20ConfidentialIndicatorNoOp();
+    }
+
+    function transferFrom(address, address, uint256) public pure override returns (bool) {
+        revert ERC20ConfidentialIndicatorNoOp();
+    }
+
+    function approve(address, uint256) public pure override returns (bool) {
+        revert ERC20ConfidentialIndicatorNoOp();
+    }
+
+    function allowance(address, address) public pure override returns (uint256) {
+        revert ERC20ConfidentialIndicatorNoOp();
+    }
+}

--- a/contracts/extensions/IERC20Confidential.sol
+++ b/contracts/extensions/IERC20Confidential.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import { euint64, InEuint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+
+/**
+ * @title IERC20Confidential
+ * @dev Interface for ERC20 tokens with confidential functionality
+ */
+interface IERC20Confidential {
+    /**
+     * @dev Returns the confidential balance of an account (encrypted)
+     */
+    function confidentialBalanceOf(address account) external view returns (euint64);
+
+    /**
+     * @dev Returns true if `spender` is currently an operator for `holder`
+     */
+    function isOperator(address holder, address spender) external view returns (bool);
+
+    /**
+     * @dev Transfer confidential tokens to another account
+     * @param to The address to transfer to
+     * @param value The encrypted amount to transfer
+     * @return transferred The actual amount transferred (may be less than requested)
+     */
+    function confidentialTransfer(address to, euint64 value) external returns (euint64 transferred);
+
+    /**
+     * @dev Transfer confidential tokens to another account (with InEuint64 input)
+     * @param to The address to transfer to
+     * @param inValue The encrypted amount to transfer
+     * @return transferred The actual amount transferred (may be less than requested)
+     */
+    function confidentialTransfer(address to, InEuint64 memory inValue) external returns (euint64 transferred);
+
+    /**
+     * @dev Transfer confidential tokens from one account to another (with operator approval)
+     * @param from The address to transfer from
+     * @param to The address to transfer to
+     * @param value The encrypted amount to transfer
+     * @return transferred The actual amount transferred (may be less than requested)
+     */
+    function confidentialTransferFrom(address from, address to, euint64 value) external returns (euint64 transferred);
+
+    /**
+     * @dev Transfer confidential tokens from one account to another (with InEuint64 input)
+     * @param from The address to transfer from
+     * @param to The address to transfer to
+     * @param inValue The encrypted amount to transfer
+     * @return transferred The actual amount transferred (may be less than requested)
+     */
+    function confidentialTransferFrom(
+        address from,
+        address to,
+        InEuint64 memory inValue
+    ) external returns (euint64 transferred);
+
+    /**
+     * @dev Wrap public tokens to confidential tokens
+     * @param amount The amount of public tokens to wrap
+     */
+    function wrap(uint64 amount) external;
+
+    /**
+     * @dev Unwrap confidential tokens to public tokens
+     * @param amount The amount of confidential tokens to unwrap
+     */
+    function unwrap(uint64 amount) external;
+
+    /**
+     * @dev Set an operator for confidential transfers
+     * @param operator The address to set as operator
+     * @param until The timestamp until which the operator is valid
+     */
+    function setOperator(address operator, uint48 until) external;
+
+    /**
+     * @dev Claim unwrapped tokens after decryption is complete
+     */
+    function claimUnwrapped() external;
+
+    /**
+     * @dev Emitted when confidential tokens are transferred
+     */
+    event ConfidentialTransfer(address indexed from, address indexed to, uint256 amountHash);
+
+    /**
+     * @dev Emitted when tokens are wrapped (converted from public to confidential)
+     */
+    event TokensWrapped(address indexed account, uint64 amount);
+
+    /**
+     * @dev Emitted when tokens are unwrapped (converted from confidential to public)
+     */
+    event TokensUnwrapped(address indexed account, uint256 amountHash);
+
+    /**
+     * @dev Emitted when unwrapped tokens are claimed
+     */
+    event UnwrappedTokensClaimed(address indexed account, uint64 amount);
+
+    /**
+     * @dev Emitted when an operator is set
+     */
+    event OperatorSet(address indexed holder, address indexed operator, uint48 until);
+}

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,0 +1,3 @@
+@openzeppelin/contracts/=node_modules/@openzeppelin/contracts/
+@fhenixprotocol/cofhe-contracts/=node_modules/@fhenixprotocol/cofhe-contracts/
+@fhenixprotocol/cofhe-mock-contracts/=node_modules/@fhenixprotocol/cofhe-mock-contracts/


### PR DESCRIPTION
Extension for an ERC20 contract that adds confidential balances and confidential transfers without affecting the ERC20 functionality. Much of the confidential logic is pulled from the existing `FHERC20.sol` contract.

Usage:
```solidity
contract MyToken is ERC20, ERC20Confidential {
    constructor() ERC20("MyToken", "MTK") ERC20Confidential("MyToken", "MTK") {}
}
```

The `MyToken` contract above will have dual-balances, one that is a public balance (existing) and a confidential balance that is queried by calling `MyToken.confidantialBalanceOf(...)` which returns an euint64. 

Relevant functions:
- `wrap()` - Wraps a user's public balance into a confidential balance.
- `unwrap()` - Unwraps a user's confidential balance back into a public balance. This is a two step process and requires a call to `claimUnwrapped()` after the FHE.decrypt has resolved. (for more info look to `FHERC20Wrapper.sol`).
- `confidentialTransfer()` - Transfer confidential funds.
- `confidentialTransferFrom()` - Checks if the caller is an `operator` and transfers confidential funds.

When a user wraps their tokens, the tokens are transferred out of the user's wallet into a shared "confidential pool", at the address `0x1011000000000000000000000000000000000000`, and the reverse happens during the unwrap process. This address starts with `1011000` which I'm calling the "confidential tag" (it is the letter X converted to binary). We will use this tag in many places to show the user at a glance that they are dealing with confidential stuff.

This PR includes an `IERC20Confidential` interface.

### ERC20ConfidentialIndicator

This is a secondary contract included in the PR, it essentially extracts the indicated balances from `FHERC20` and puts them in their own contract. This contract is deployed during the creation of an `ERC20Confidential` contract, and is called whenever a confidential transfer takes place. Its name is `1011000 {tokenName}` and symbol `c{tokenSymbol}`. When a user makes a confidential transfer, the indicated contract will emit an event with an indicated transfer amount of `101100.0001` (note the confidential tag). And the indicated balances (fetched with `balanceOf`) will be updated (`1011000.5453` -> `1011000.5454`).

User's can add this indicated token contract to their wallet to see their indicated balance change (of course this is optional). If the user calls `USDC.confidentialTransfer()`, in a block explorer you would see a token transfer that looks like `0xAAA..AAA -> 0xBBB...BBB 1011000.0001 cUSDC`.
