### PR TITLE
docs: add project documentation and prepare v0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2025-01-21
+
+### Added
+- Initial release of FHERC20 confidential token standard
+- FHERC20Permit for EIP-712 signature-based operator approval
+- FHERC20Wrapper for wrapping standard ERC-20 tokens
+- FHERC20UnwrapClaim for managing unwrap claims
+- Comprehensive interface definitions (IFHERC20, IFHERC20Permit, IFHERC20Errors, IFHERC20Receiver)
+- FHERC20Utils library for transfer callbacks
+- FHESafeMath utility library
+- `confidentialTransferAndCall` and `confidentialTransferFromAndCall` functions for contract callbacks
+
+### Security
+- Implemented operator model replacing traditional ERC-20 allowances
+- Added indicator balance system for backwards compatibility without revealing actual amounts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,160 @@
+# Contributing to Fhenix Confidential Contracts
+
+Thank you for your interest in contributing to Fhenix Confidential Contracts! This document provides guidelines for contributing to this project.
+
+## Code of Conduct
+
+By participating in this project, you agree to maintain a respectful and inclusive environment. We expect all contributors to:
+
+- Use welcoming and inclusive language
+- Be respectful of differing viewpoints and experiences
+- Accept constructive criticism gracefully
+- Focus on what is best for the community
+
+## How to Contribute
+
+### Reporting Issues
+
+Before opening an issue:
+
+1. **Search existing issues** to avoid duplicates
+2. **Check closed issues** - your problem may have been resolved
+
+When creating an issue:
+
+- Use a clear and descriptive title
+- Provide detailed reproduction steps
+- Include relevant code snippets
+- Specify your environment (Solidity version, Node.js version, etc.)
+
+### Security Vulnerabilities
+
+**DO NOT** open a public issue for security vulnerabilities. Please use [GitHub Security Advisories](https://github.com/FhenixProtocol/fhenix-confidential-contracts/security/advisories/new) instead.
+
+### Feature Requests
+
+Feature requests are welcome! Please:
+
+1. Explain the use case in detail
+2. Describe the expected behavior
+3. Consider if it aligns with the project's goals
+
+### Pull Request Process
+
+#### Before Starting Work
+
+1. **Open an issue first** for non-trivial changes
+2. **Discuss the approach** with maintainers
+3. **Check that no one else is working on it**
+
+#### Development Setup
+
+```bash
+# Clone the repository
+git clone https://github.com/FhenixProtocol/fhenix-confidential-contracts.git
+cd fhenix-confidential-contracts
+
+# Install dependencies
+pnpm install
+
+# Run tests
+pnpm test
+```
+
+#### Code Style Requirements
+
+**Solidity**
+- Follow [Solidity Style Guide](https://docs.soliditylang.org/en/latest/style-guide.html)
+- Use NatSpec comments for all public functions
+- Maximum line length: 120 characters
+- Run `pnpm format` before committing
+
+**TypeScript**
+- Follow ESLint configuration
+- Run `pnpm lint` before committing
+
+#### Testing Requirements
+
+All code changes must include appropriate tests:
+
+```bash
+# Run full test suite
+pnpm test
+
+# Run with gas reporting
+pnpm gas
+```
+
+- Aim for high test coverage
+- Test both success and failure cases
+- Include edge cases
+
+#### Commit Messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+Types:
+- `feat`: New feature
+- `fix`: Bug fix
+- `docs`: Documentation changes
+- `style`: Code style changes (formatting, etc.)
+- `refactor`: Code refactoring
+- `test`: Adding or updating tests
+- `chore`: Maintenance tasks
+
+Examples:
+```
+feat(FHERC20): add batch transfer functionality
+fix(FHERC20Permit): correct nonce validation logic
+docs(README): update installation instructions
+```
+
+#### Pull Request Guidelines
+
+1. **Create a feature branch** from `master`
+2. **Keep changes focused** - one feature/fix per PR
+3. **Update documentation** as needed
+4. **Update CHANGELOG.md** for user-facing changes
+5. **Ensure CI passes** before requesting review
+
+PR Title Format:
+```
+<type>(<scope>): <description>
+```
+
+#### Review Process
+
+1. At least one maintainer approval required
+2. All CI checks must pass
+3. Changes may be requested - please respond promptly
+4. Once approved, maintainers will merge
+
+## Versioning
+
+This project follows [Semantic Versioning](https://semver.org/):
+
+- **MAJOR**: Incompatible API changes
+- **MINOR**: New features (backwards compatible)
+- **PATCH**: Bug fixes (backwards compatible)
+
+### Pre-release Versions
+
+- `X.Y.Z-alpha.N`: Early development
+- `X.Y.Z-beta.N`: Feature complete, testing
+- `X.Y.Z-rc.N`: Release candidate
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the MIT License.
+
+## Questions?
+
+Feel free to open a discussion or reach out to the maintainers.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 FHE Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,210 @@
+# Fhenix Confidential Contracts
+
+[![NPM Package](https://img.shields.io/npm/v/fhenix-confidential-contracts.svg)](https://www.npmjs.org/package/fhenix-confidential-contracts)
+[![CI Status](https://github.com/FhenixProtocol/fhenix-confidential-contracts/actions/workflows/test.yml/badge.svg)](https://github.com/FhenixProtocol/fhenix-confidential-contracts/actions/workflows/test.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+**A privacy-preserving FHERC-20 token standard implementation built on Fhenix Protocol's Fully Homomorphic Encryption (FHE).**
+
+> **Warning**: These contracts are in active development and have not been audited. Use at your own risk.
+
+## Overview
+
+This library provides Solidity smart contracts for confidential ERC-20 tokens using FHE. Token balances and transfer amounts remain encrypted on-chain while still supporting standard token operations.
+
+### Key Features
+
+- **FHERC20** - Base confidential token with encrypted balances
+- **FHERC20Permit** - EIP-712 signature-based operator approval
+- **FHERC20Wrapper** - Wrap standard ERC-20 tokens into confidential tokens
+- **FHERC20UnwrapClaim** - Claim management for unwrapping back to ERC-20
+
+## Installation
+
+### Hardhat (npm/yarn/pnpm)
+
+```bash
+npm install fhenix-confidential-contracts
+# or
+yarn add fhenix-confidential-contracts
+# or
+pnpm add fhenix-confidential-contracts
+```
+
+### Foundry
+
+```bash
+forge install FhenixProtocol/fhenix-confidential-contracts
+```
+
+## Usage
+
+### Basic FHERC20 Token
+
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { FHERC20 } from "fhenix-confidential-contracts/contracts/FHERC20.sol";
+
+contract MyConfidentialToken is FHERC20 {
+    constructor() FHERC20("My Confidential Token", "eMCT", 18) {
+        // Mint initial supply to deployer
+        _mint(msg.sender, 1000000 * 10**18);
+    }
+}
+```
+
+### FHERC20 with Permit
+
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { FHERC20 } from "fhenix-confidential-contracts/contracts/FHERC20.sol";
+import { FHERC20Permit } from "fhenix-confidential-contracts/contracts/FHERC20Permit.sol";
+
+contract MyPermitToken is FHERC20, FHERC20Permit {
+    constructor()
+        FHERC20("My Permit Token", "eMPT", 18)
+        FHERC20Permit("My Permit Token")
+    {
+        _mint(msg.sender, 1000000 * 10**18);
+    }
+}
+```
+
+### Wrapping Existing ERC-20 Tokens
+
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { FHERC20Wrapper } from "fhenix-confidential-contracts/contracts/FHERC20Wrapper.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract MyWrappedToken is FHERC20Wrapper {
+    constructor(IERC20 underlyingToken)
+        FHERC20Wrapper(underlyingToken, "")
+    {}
+}
+
+// Usage:
+// 1. Deploy with existing ERC-20 address
+// 2. Approve the wrapper contract to spend your ERC-20 tokens
+// 3. Call wrap(recipient, amount) to mint confidential tokens
+// 4. Call unwrap(recipient, encryptedAmount) to initiate unwrapping
+// 5. Call claimUnwrapped(ctHash) after decryption completes
+```
+
+## Contract Architecture
+
+```
+FHERC20 (base)
+├── FHERC20Permit (EIP-712 signatures)
+└── FHERC20Wrapper (ERC-20 wrapping)
+    └── FHERC20UnwrapClaim (claim management)
+
+Interfaces:
+├── IFHERC20
+├── IFHERC20Permit
+├── IFHERC20Errors
+├── IFHERC20Receiver
+└── IWETH
+
+Utilities:
+├── FHERC20Utils
+└── FHESafeMath
+```
+
+## Key Concepts
+
+### Indicated Balances
+
+FHERC20 tokens use an "indicator" system for backwards compatibility with existing ERC-20 infrastructure (wallets, block explorers). The `balanceOf` function returns a value between `0.0000` and `0.9999` that indicates balance changes without revealing actual amounts.
+
+This allows wallets to detect when balances change while keeping the actual amounts private.
+
+### Operators vs Allowances
+
+Traditional ERC-20 allowances are replaced with time-limited **operators** to prevent encrypted balance leakage. Unlike allowances where you approve a specific amount, operators can transfer any amount on behalf of a holder until their permission expires.
+
+```solidity
+// Set an operator (replaces approve)
+token.setOperator(spender, deadline);
+
+// Check if address is an operator
+bool isOp = token.isOperator(holder, spender);
+
+// Transfer as operator (replaces transferFrom with allowance)
+token.confidentialTransferFrom(from, to, encryptedAmount);
+```
+
+### Confidential Transfers
+
+```solidity
+// Direct encrypted transfer
+token.confidentialTransfer(to, encryptedAmount);
+
+// Operator-initiated transfer
+token.confidentialTransferFrom(from, to, encryptedAmount);
+
+// Transfer with callback to receiving contract
+token.confidentialTransferAndCall(to, encryptedAmount, data);
+```
+
+## Security Considerations
+
+### FHE-Specific Security
+
+1. **Balance Indicators Are Public**: The indicator values (0.0000-0.9999) reveal transfer activity but not amounts
+2. **Operator Model**: Operators have full transfer authority during their approval period - use short deadlines
+3. **Decryption Delays**: Unwrapping operations require waiting for FHE decryption to complete
+
+### Smart Contract Security
+
+1. **Reentrancy**: `confidentialTransferAndCall` includes callback functionality - receiving contracts should follow checks-effects-interactions
+2. **Integer Operations**: FHE operations have different overflow behavior than standard Solidity
+
+### Audit Status
+
+> **Warning**: These contracts have not been audited. A security audit is planned before v1.0.0 release.
+
+### Reporting Vulnerabilities
+
+Please report security vulnerabilities through our [Security Policy](./SECURITY.md).
+
+## Dependencies
+
+- [@openzeppelin/contracts](https://github.com/OpenZeppelin/openzeppelin-contracts) ^5.2.0
+- [@fhenixprotocol/cofhe-contracts](https://github.com/FhenixProtocol/cofhe-contracts) 0.0.13
+
+## Development
+
+```bash
+# Install dependencies
+pnpm install
+
+# Compile contracts
+pnpm compile
+
+# Run tests
+pnpm test
+
+# Run tests with gas reporting
+pnpm gas
+
+# Format code
+pnpm format
+
+# Lint
+pnpm lint
+```
+
+## Contributing
+
+Contributions are welcome! Please read our [Contributing Guide](./CONTRIBUTING.md) before submitting a Pull Request.
+
+## License
+
+Released under the [MIT License](./LICENSE).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,32 @@
 {
   "name": "fhenix-confidential-contracts",
-  "version": "0.0.1",
+  "version": "0.1.0",
+  "description": "Privacy-preserving FHERC-20 token standard for Fhenix Protocol",
+  "license": "MIT",
+  "author": "fhenixprotocol",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FhenixProtocol/fhenix-confidential-contracts.git"
+  },
+  "homepage": "https://github.com/FhenixProtocol/fhenix-confidential-contracts#readme",
+  "bugs": {
+    "url": "https://github.com/FhenixProtocol/fhenix-confidential-contracts/issues"
+  },
+  "keywords": [
+    "solidity",
+    "ethereum",
+    "fhe",
+    "fhenix",
+    "privacy",
+    "erc20",
+    "fherc20",
+    "confidential",
+    "smart-contracts"
+  ],
+  "files": [
+    "contracts/**/*.sol",
+    "!contracts/test/**/*"
+  ],
   "scripts": {
     "check-types": "tsc --noEmit --incremental",
     "clean": "hardhat clean",


### PR DESCRIPTION

This PR adds essential project documentation following GitHub best practices:

- **LICENSE** - MIT license with FHE Labs copyright
- **README.md** - Installation, usage examples, contract architecture, security considerations
- **CONTRIBUTING.md** - Code style, PR process, commit conventions
- **CHANGELOG.md** - v0.1.0 release notes
- **package.json** - npm metadata for publishing

### Post-Merge Steps

After merging this PR, I suggest creating  the v0.1.0 tag and publish on npm if possible
