### PR TITLE
fix: cast euint64 transferred to bytes32 in ConfidentialTransfer

### DIFF
--- a/contracts/FHERC20.sol
+++ b/contracts/FHERC20.sol
@@ -440,7 +440,7 @@ abstract contract FHERC20 is IFHERC20, IFHERC20Errors, Context {
         FHE.allowThis(_encTotalSupply);
 
         emit Transfer(from, to, _indicatorTick);
-        emit ConfidentialTransfer(from, to, euint64.unwrap(transferred));
+        emit ConfidentialTransfer(from, to, bytes32(euint64.unwrap(transferred)));
     }
 
     /**


### PR DESCRIPTION
### Description
In `FHERC20.sol`, (line 443), the `ConfidentialTransfer` event is currently being emitted with `euint64.unwrap(transferred)`, which returns a native `uint256`. However, the `IFHERC20.sol` interface defines the 3rd parameter (`value_hash`) strictly as a `bytes32`. 

This mismatch currently causes a compiler error for users:  
`Invalid implicit conversion from uint256 to bytes32 requested`.

### Changes Made
- Added a missing explicit cast to `bytes32(euint64.unwrap(transferred))` inside the emit statement to satisfy the interface ABI, allowing the FHERC20 contract to successfully compile.
