### PR TITLE
ERC7984

### DIFF
--- a/contracts/ERC7984/ERC7984.sol
+++ b/contracts/ERC7984/ERC7984.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { FHE, Utils, euint64, InEuint64, ebool } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+import { FHE, euint64, InEuint64, ebool } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { Context } from "@openzeppelin/contracts/utils/Context.sol";
@@ -73,9 +73,6 @@ abstract contract ERC7984 is IERC7984, Context, ERC165 {
 
     /// @dev The given caller `caller` is not authorized for the current operation.
     error ERC7984UnauthorizedCaller(address caller);
-
-    /// @dev The given gateway request ID `requestId` is invalid.
-    error ERC7984InvalidGatewayRequest(uint256 requestId);
 
     /// @dev Reverts when a cleartext ERC-20 function is called on a confidential token.
     error ERC7984IncompatibleFunction();

--- a/contracts/ERC7984/ERC7984.sol
+++ b/contracts/ERC7984/ERC7984.sol
@@ -375,7 +375,7 @@ abstract contract ERC7984 is IERC7984, Context, ERC165 {
             _indicatedTotalSupply = _incrementIndicator(_indicatedTotalSupply);
         } else {
             euint64 fromBalance = _balances[from];
-            if (euint64.unwrap(fromBalance) == 0) revert ERC7984ZeroBalance(from);
+            if (!FHE.isInitialized(fromBalance)) revert ERC7984ZeroBalance(from);
             (success, ptr) = FHESafeMath.tryDecrease(fromBalance, amount);
             FHE.allowThis(ptr);
             FHE.allow(ptr, from);

--- a/contracts/ERC7984/ERC7984.sol
+++ b/contracts/ERC7984/ERC7984.sol
@@ -84,7 +84,7 @@ abstract contract ERC7984 is IERC7984, Context, ERC165 {
 
     /// @inheritdoc IERC7984
     function decimals() public view virtual returns (uint8) {
-        return 6;
+        return _decimals;
     }
 
     /// @inheritdoc IERC7984

--- a/contracts/ERC7984/ERC7984.sol
+++ b/contracts/ERC7984/ERC7984.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.25;
 
 import { FHE, Utils, euint64, InEuint64, ebool } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
 
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { Context } from "@openzeppelin/contracts/utils/Context.sol";
 import { ERC165 } from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import { IERC7984 } from "../interfaces/IERC7984.sol";
@@ -22,6 +23,14 @@ import { ERC7984Utils } from "./utils/ERC7984Utils.sol";
  * - Transfers happen without revealing amounts
  * - Support for operators (delegated transfer capabilities with time bounds)
  * - Safe overflow/underflow handling for FHE operations
+ *
+ * ERC-20 Compatibility:
+ *
+ * This contract implements the {IERC20} interface for backwards compatibility with wallets, block explorers,
+ * and other ERC-20 tooling. The {balanceOf} and {totalSupply} functions return **indicator values** (not real
+ * balances). The indicator starts at `7984.0000` on first interaction and shifts by `0.0001` per transfer,
+ * signalling that this is a confidential token. ERC-20 mutative functions (`transfer`, `transferFrom`,
+ * `approve`) revert unconditionally.
  */
 abstract contract ERC7984 is IERC7984, Context, ERC165 {
     mapping(address account => euint64) private _balances;
@@ -31,6 +40,14 @@ abstract contract ERC7984 is IERC7984, Context, ERC165 {
     string private _symbol;
     uint8 private _decimals;
     string private _contractURI;
+
+    // ERC-20 indicator state — see contract-level docs above.
+    mapping(address account => uint32) private _indicatedBalances;
+    uint32 private _indicatedTotalSupply;
+    uint256 private _indicatorTick;
+
+    uint32 private constant _INDICATOR_BASE = 79_840_000;
+    uint32 private constant _INDICATOR_TRANSFER = 79_840_001;
 
     /// @dev Emitted when an encrypted amount `encryptedAmount` is requested for disclosure by `requester`.
     event AmountDiscloseRequested(euint64 indexed encryptedAmount, address indexed requester);
@@ -60,17 +77,89 @@ abstract contract ERC7984 is IERC7984, Context, ERC165 {
     /// @dev The given gateway request ID `requestId` is invalid.
     error ERC7984InvalidGatewayRequest(uint256 requestId);
 
+    /// @dev Reverts when a cleartext ERC-20 function is called on a confidential token.
+    error ERC7984IncompatibleFunction();
+
     constructor(string memory name_, string memory symbol_, uint8 decimals_, string memory contractURI_) {
         _name = name_;
         _symbol = symbol_;
         _decimals = decimals_;
         _contractURI = contractURI_;
+        _indicatorTick = decimals_ <= 4 ? 1 : 10 ** (decimals_ - 4);
     }
+
+    // =========================================================================
+    //  ERC-165
+    // =========================================================================
 
     /// @inheritdoc ERC165
     function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165) returns (bool) {
-        return interfaceId == type(IERC7984).interfaceId || super.supportsInterface(interfaceId);
+        return
+            interfaceId == type(IERC7984).interfaceId ||
+            interfaceId == type(IERC20).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
+
+    // =========================================================================
+    //  ERC-20 indicator (backwards-compatible view layer)
+    // =========================================================================
+
+    /**
+     * @dev Returns an indicator of the underlying encrypted total supply. The value is **not** the
+     * real total supply — it is a counter that starts at `7984.0000` on first mint and shifts by
+     * `0.0001` per mint/burn.
+     */
+    function totalSupply() public view virtual returns (uint256) {
+        return uint256(_indicatedTotalSupply) * _indicatorTick;
+    }
+
+    /**
+     * @dev Returns an indicator of the underlying encrypted balance. The value is **not** the real
+     * balance — it is a counter that starts at `7984.0001` on first interaction and shifts by
+     * `0.0001` per send/receive. A return value of `0` means the account has never interacted.
+     */
+    function balanceOf(address account) public view virtual returns (uint256) {
+        return uint256(_indicatedBalances[account]) * _indicatorTick;
+    }
+
+    /// @dev Always reverts. Use {confidentialTransfer} instead.
+    function transfer(address, uint256) public pure returns (bool) {
+        revert ERC7984IncompatibleFunction();
+    }
+
+    /// @dev Always reverts. Use {confidentialTransferFrom} instead.
+    function transferFrom(address, address, uint256) public pure returns (bool) {
+        revert ERC7984IncompatibleFunction();
+    }
+
+    /// @dev Always reverts. Use {setOperator} instead.
+    function approve(address, uint256) public pure returns (bool) {
+        revert ERC7984IncompatibleFunction();
+    }
+
+    /// @dev Always reverts. Allowances are replaced by time-bound operators.
+    function allowance(address, address) public pure returns (uint256) {
+        revert ERC7984IncompatibleFunction();
+    }
+
+    /// @dev Returns `true`, signalling that {balanceOf} returns an indicator, not a real balance.
+    function balanceOfIsIndicator() public pure virtual returns (bool) {
+        return true;
+    }
+
+    /// @dev Returns the raw unit size of a single indicator tick (scales with {decimals}).
+    function indicatorTick() public view returns (uint256) {
+        return _indicatorTick;
+    }
+
+    /// @dev Resets the caller's indicated balance to `0` (no interaction).
+    function resetIndicatedBalance() external {
+        _indicatedBalances[msg.sender] = 0;
+    }
+
+    // =========================================================================
+    //  IERC7984 view functions
+    // =========================================================================
 
     /// @inheritdoc IERC7984
     function name() public view virtual returns (string memory) {
@@ -106,6 +195,10 @@ abstract contract ERC7984 is IERC7984, Context, ERC165 {
     function isOperator(address holder, address spender) public view virtual returns (bool) {
         return holder == spender || block.timestamp <= _operators[holder][spender];
     }
+
+    // =========================================================================
+    //  IERC7984 mutative functions
+    // =========================================================================
 
     /// @inheritdoc IERC7984
     function setOperator(address operator, uint48 until) public virtual {
@@ -192,6 +285,10 @@ abstract contract ERC7984 is IERC7984, Context, ERC165 {
         FHE.allowTransient(transferred, msg.sender);
     }
 
+    // =========================================================================
+    //  Disclosure
+    // =========================================================================
+
     /**
      * @dev Starts the process to disclose an encrypted amount `encryptedAmount` publicly by making it
      * publicly decryptable. Emits the {AmountDiscloseRequested} event.
@@ -221,6 +318,10 @@ abstract contract ERC7984 is IERC7984, Context, ERC165 {
         emit AmountDisclosed(encryptedAmount, cleartextAmount);
     }
 
+    // =========================================================================
+    //  Internal helpers
+    // =========================================================================
+
     function _setOperator(address holder, address operator, uint48 until) internal virtual {
         _operators[holder][operator] = until;
         emit OperatorSet(holder, operator, until);
@@ -248,15 +349,22 @@ abstract contract ERC7984 is IERC7984, Context, ERC165 {
         euint64 amount,
         bytes calldata data
     ) internal returns (euint64 transferred) {
-        // Try to transfer amount + replace input with actually transferred amount.
         euint64 sent = _transfer(from, to, amount);
 
-        // Perform callback
         ebool success = ERC7984Utils.checkOnTransferReceived(msg.sender, from, to, sent, data);
 
-        // Try to refund if callback fails
         euint64 refund = _update(to, from, FHE.select(success, FHE.asEuint64(0), sent));
         transferred = FHE.sub(sent, refund);
+    }
+
+    function _incrementIndicator(uint32 current) internal pure returns (uint32) {
+        if (current == 0) return _INDICATOR_BASE + 1;
+        return current + 1;
+    }
+
+    function _decrementIndicator(uint32 current) internal pure returns (uint32) {
+        if (current == 0) return _INDICATOR_BASE;
+        return current - 1;
     }
 
     function _update(address from, address to, euint64 amount) internal virtual returns (euint64 transferred) {
@@ -267,6 +375,7 @@ abstract contract ERC7984 is IERC7984, Context, ERC165 {
             (success, ptr) = FHESafeMath.tryIncrease(_totalSupply, amount);
             FHE.allowThis(ptr);
             _totalSupply = ptr;
+            _indicatedTotalSupply = _incrementIndicator(_indicatedTotalSupply);
         } else {
             euint64 fromBalance = _balances[from];
             if (euint64.unwrap(fromBalance) == 0) revert ERC7984ZeroBalance(from);
@@ -274,6 +383,7 @@ abstract contract ERC7984 is IERC7984, Context, ERC165 {
             FHE.allowThis(ptr);
             FHE.allow(ptr, from);
             _balances[from] = ptr;
+            _indicatedBalances[from] = _decrementIndicator(_indicatedBalances[from]);
         }
 
         transferred = FHE.select(success, amount, FHE.asEuint64(0));
@@ -282,16 +392,20 @@ abstract contract ERC7984 is IERC7984, Context, ERC165 {
             ptr = FHE.sub(_totalSupply, transferred);
             FHE.allowThis(ptr);
             _totalSupply = ptr;
+            _indicatedTotalSupply = _decrementIndicator(_indicatedTotalSupply);
         } else {
             ptr = FHE.add(_balances[to], transferred);
             FHE.allowThis(ptr);
             FHE.allow(ptr, to);
             _balances[to] = ptr;
+            _indicatedBalances[to] = _incrementIndicator(_indicatedBalances[to]);
         }
 
         if (from != address(0)) FHE.allow(transferred, from);
         if (to != address(0)) FHE.allow(transferred, to);
         FHE.allowThis(transferred);
+
+        emit Transfer(from, to, uint256(_INDICATOR_TRANSFER) * _indicatorTick);
         emit ConfidentialTransfer(from, to, transferred);
     }
 }

--- a/contracts/ERC7984/ERC7984.sol
+++ b/contracts/ERC7984/ERC7984.sol
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { FHE, Utils, euint64, InEuint64, ebool } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+
+import { Context } from "@openzeppelin/contracts/utils/Context.sol";
+import { ERC165 } from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import { IERC7984 } from "../interfaces/IERC7984.sol";
+import { FHESafeMath } from "../utils/FHESafeMath.sol";
+import { ERC7984Utils } from "./utils/ERC7984Utils.sol";
+
+/**
+ * @dev Reference implementation for {IERC7984}.
+ *
+ * This contract implements a fungible token where balances and transfers are encrypted using the Fhenix CoFHE coprocessor,
+ * providing confidentiality to users. Token amounts are stored as encrypted, unsigned integers (`euint64`)
+ * that can only be decrypted by authorized parties.
+ *
+ * Key features:
+ *
+ * - All balances are encrypted
+ * - Transfers happen without revealing amounts
+ * - Support for operators (delegated transfer capabilities with time bounds)
+ * - Safe overflow/underflow handling for FHE operations
+ */
+abstract contract ERC7984 is IERC7984, Context, ERC165 {
+    mapping(address account => euint64) private _balances;
+    mapping(address account => mapping(address spender => uint48)) internal _operators;
+    euint64 private _totalSupply;
+    string private _name;
+    string private _symbol;
+    uint8 private _decimals;
+    string private _contractURI;
+
+    /// @dev Emitted when an encrypted amount `encryptedAmount` is requested for disclosure by `requester`.
+    event AmountDiscloseRequested(euint64 indexed encryptedAmount, address indexed requester);
+
+    /// @dev The given receiver `receiver` is invalid for transfers.
+    error ERC7984InvalidReceiver(address receiver);
+
+    /// @dev The given sender `sender` is invalid for transfers.
+    error ERC7984InvalidSender(address sender);
+
+    /// @dev The given holder `holder` is not authorized to spend on behalf of `spender`.
+    error ERC7984UnauthorizedSpender(address holder, address spender);
+
+    /// @dev The holder `holder` is trying to send tokens but has a balance of 0.
+    error ERC7984ZeroBalance(address holder);
+
+    /**
+     * @dev The caller `user` does not have access to the encrypted amount `amount`.
+     *
+     * NOTE: Try using the equivalent transfer function with an input proof.
+     */
+    error ERC7984UnauthorizedUseOfEncryptedAmount(euint64 amount, address user);
+
+    /// @dev The given caller `caller` is not authorized for the current operation.
+    error ERC7984UnauthorizedCaller(address caller);
+
+    /// @dev The given gateway request ID `requestId` is invalid.
+    error ERC7984InvalidGatewayRequest(uint256 requestId);
+
+    constructor(string memory name_, string memory symbol_, uint8 decimals_, string memory contractURI_) {
+        _name = name_;
+        _symbol = symbol_;
+        _decimals = decimals_;
+        _contractURI = contractURI_;
+    }
+
+    /// @inheritdoc ERC165
+    function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165) returns (bool) {
+        return interfaceId == type(IERC7984).interfaceId || super.supportsInterface(interfaceId);
+    }
+
+    /// @inheritdoc IERC7984
+    function name() public view virtual returns (string memory) {
+        return _name;
+    }
+
+    /// @inheritdoc IERC7984
+    function symbol() public view virtual returns (string memory) {
+        return _symbol;
+    }
+
+    /// @inheritdoc IERC7984
+    function decimals() public view virtual returns (uint8) {
+        return 6;
+    }
+
+    /// @inheritdoc IERC7984
+    function contractURI() public view virtual returns (string memory) {
+        return _contractURI;
+    }
+
+    /// @inheritdoc IERC7984
+    function confidentialTotalSupply() public view virtual returns (euint64) {
+        return _totalSupply;
+    }
+
+    /// @inheritdoc IERC7984
+    function confidentialBalanceOf(address account) public view virtual returns (euint64) {
+        return _balances[account];
+    }
+
+    /// @inheritdoc IERC7984
+    function isOperator(address holder, address spender) public view virtual returns (bool) {
+        return holder == spender || block.timestamp <= _operators[holder][spender];
+    }
+
+    /// @inheritdoc IERC7984
+    function setOperator(address operator, uint48 until) public virtual {
+        _setOperator(msg.sender, operator, until);
+    }
+
+    /// @inheritdoc IERC7984
+    function confidentialTransfer(address to, InEuint64 memory encryptedAmount) public virtual returns (euint64) {
+        return _transfer(msg.sender, to, FHE.asEuint64(encryptedAmount));
+    }
+
+    /// @inheritdoc IERC7984
+    function confidentialTransfer(address to, euint64 amount) public virtual returns (euint64) {
+        if (!FHE.isAllowed(amount, msg.sender)) revert ERC7984UnauthorizedUseOfEncryptedAmount(amount, msg.sender);
+        return _transfer(msg.sender, to, amount);
+    }
+
+    /// @inheritdoc IERC7984
+    function confidentialTransferFrom(
+        address from,
+        address to,
+        InEuint64 memory encryptedAmount
+    ) public virtual returns (euint64 transferred) {
+        if (!isOperator(from, msg.sender)) revert ERC7984UnauthorizedSpender(from, msg.sender);
+        transferred = _transfer(from, to, FHE.asEuint64(encryptedAmount));
+        FHE.allowTransient(transferred, msg.sender);
+    }
+
+    /// @inheritdoc IERC7984
+    function confidentialTransferFrom(
+        address from,
+        address to,
+        euint64 amount
+    ) public virtual returns (euint64 transferred) {
+        if (!FHE.isAllowed(amount, msg.sender)) revert ERC7984UnauthorizedUseOfEncryptedAmount(amount, msg.sender);
+        if (!isOperator(from, msg.sender)) revert ERC7984UnauthorizedSpender(from, msg.sender);
+        transferred = _transfer(from, to, amount);
+        FHE.allowTransient(transferred, msg.sender);
+    }
+
+    /// @inheritdoc IERC7984
+    function confidentialTransferAndCall(
+        address to,
+        InEuint64 memory encryptedAmount,
+        bytes calldata data
+    ) public virtual returns (euint64 transferred) {
+        transferred = _transferAndCall(msg.sender, to, FHE.asEuint64(encryptedAmount), data);
+        FHE.allowTransient(transferred, msg.sender);
+    }
+
+    /// @inheritdoc IERC7984
+    function confidentialTransferAndCall(
+        address to,
+        euint64 amount,
+        bytes calldata data
+    ) public virtual returns (euint64 transferred) {
+        if (!FHE.isAllowed(amount, msg.sender)) revert ERC7984UnauthorizedUseOfEncryptedAmount(amount, msg.sender);
+        transferred = _transferAndCall(msg.sender, to, amount, data);
+        FHE.allowTransient(transferred, msg.sender);
+    }
+
+    /// @inheritdoc IERC7984
+    function confidentialTransferFromAndCall(
+        address from,
+        address to,
+        InEuint64 memory encryptedAmount,
+        bytes calldata data
+    ) public virtual returns (euint64 transferred) {
+        if (!isOperator(from, msg.sender)) revert ERC7984UnauthorizedSpender(from, msg.sender);
+        transferred = _transferAndCall(from, to, FHE.asEuint64(encryptedAmount), data);
+        FHE.allowTransient(transferred, msg.sender);
+    }
+
+    /// @inheritdoc IERC7984
+    function confidentialTransferFromAndCall(
+        address from,
+        address to,
+        euint64 amount,
+        bytes calldata data
+    ) public virtual returns (euint64 transferred) {
+        if (!FHE.isAllowed(amount, msg.sender)) revert ERC7984UnauthorizedUseOfEncryptedAmount(amount, msg.sender);
+        if (!isOperator(from, msg.sender)) revert ERC7984UnauthorizedSpender(from, msg.sender);
+        transferred = _transferAndCall(from, to, amount, data);
+        FHE.allowTransient(transferred, msg.sender);
+    }
+
+    /**
+     * @dev Starts the process to disclose an encrypted amount `encryptedAmount` publicly by making it
+     * publicly decryptable. Emits the {AmountDiscloseRequested} event.
+     *
+     * NOTE: Both `msg.sender` and `address(this)` must have permission to access the encrypted amount
+     * `encryptedAmount` to request disclosure of the encrypted amount `encryptedAmount`.
+     */
+    function requestDiscloseEncryptedAmount(euint64 encryptedAmount) public virtual {
+        if (!FHE.isAllowed(encryptedAmount, msg.sender))
+            revert ERC7984UnauthorizedUseOfEncryptedAmount(encryptedAmount, msg.sender);
+
+        FHE.allowPublic(encryptedAmount);
+        emit AmountDiscloseRequested(encryptedAmount, msg.sender);
+    }
+
+    /**
+     * @dev Publicly discloses an encrypted value with a given decryption proof. Emits the {AmountDisclosed} event.
+     *
+     * NOTE: May not be tied to a prior request via {requestDiscloseEncryptedAmount}.
+     */
+    function discloseEncryptedAmount(
+        euint64 encryptedAmount,
+        uint64 cleartextAmount,
+        bytes calldata decryptionProof
+    ) public virtual {
+        FHE.verifyDecryptResult(encryptedAmount, cleartextAmount, decryptionProof);
+        emit AmountDisclosed(encryptedAmount, cleartextAmount);
+    }
+
+    function _setOperator(address holder, address operator, uint48 until) internal virtual {
+        _operators[holder][operator] = until;
+        emit OperatorSet(holder, operator, until);
+    }
+
+    function _mint(address to, euint64 amount) internal returns (euint64 transferred) {
+        if (to == address(0)) revert ERC7984InvalidReceiver(address(0));
+        return _update(address(0), to, amount);
+    }
+
+    function _burn(address from, euint64 amount) internal returns (euint64 transferred) {
+        if (from == address(0)) revert ERC7984InvalidSender(address(0));
+        return _update(from, address(0), amount);
+    }
+
+    function _transfer(address from, address to, euint64 amount) internal returns (euint64 transferred) {
+        if (from == address(0)) revert ERC7984InvalidSender(address(0));
+        if (to == address(0)) revert ERC7984InvalidReceiver(address(0));
+        return _update(from, to, amount);
+    }
+
+    function _transferAndCall(
+        address from,
+        address to,
+        euint64 amount,
+        bytes calldata data
+    ) internal returns (euint64 transferred) {
+        // Try to transfer amount + replace input with actually transferred amount.
+        euint64 sent = _transfer(from, to, amount);
+
+        // Perform callback
+        ebool success = ERC7984Utils.checkOnTransferReceived(msg.sender, from, to, sent, data);
+
+        // Try to refund if callback fails
+        euint64 refund = _update(to, from, FHE.select(success, FHE.asEuint64(0), sent));
+        transferred = FHE.sub(sent, refund);
+    }
+
+    function _update(address from, address to, euint64 amount) internal virtual returns (euint64 transferred) {
+        ebool success;
+        euint64 ptr;
+
+        if (from == address(0)) {
+            (success, ptr) = FHESafeMath.tryIncrease(_totalSupply, amount);
+            FHE.allowThis(ptr);
+            _totalSupply = ptr;
+        } else {
+            euint64 fromBalance = _balances[from];
+            if (euint64.unwrap(fromBalance) == 0) revert ERC7984ZeroBalance(from);
+            (success, ptr) = FHESafeMath.tryDecrease(fromBalance, amount);
+            FHE.allowThis(ptr);
+            FHE.allow(ptr, from);
+            _balances[from] = ptr;
+        }
+
+        transferred = FHE.select(success, amount, FHE.asEuint64(0));
+
+        if (to == address(0)) {
+            ptr = FHE.sub(_totalSupply, transferred);
+            FHE.allowThis(ptr);
+            _totalSupply = ptr;
+        } else {
+            ptr = FHE.add(_balances[to], transferred);
+            FHE.allowThis(ptr);
+            FHE.allow(ptr, to);
+            _balances[to] = ptr;
+        }
+
+        if (from != address(0)) FHE.allow(transferred, from);
+        if (to != address(0)) FHE.allow(transferred, to);
+        FHE.allowThis(transferred);
+        emit ConfidentialTransfer(from, to, transferred);
+    }
+}

--- a/contracts/ERC7984/extensions/ERC7984ERC20Wrapper.sol
+++ b/contracts/ERC7984/extensions/ERC7984ERC20Wrapper.sol
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { FHE, euint64, InEuint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+import { IERC1363Receiver } from "@openzeppelin/contracts/interfaces/IERC1363Receiver.sol";
+import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
+import { IERC20Metadata } from "@openzeppelin/contracts/interfaces/IERC20Metadata.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import { IERC7984 } from "../../interfaces/IERC7984.sol";
+import { IERC7984ERC20Wrapper } from "../../interfaces/IERC7984ERC20Wrapper.sol";
+import { ERC7984 } from "../ERC7984.sol";
+
+/**
+ * @dev A wrapper contract built on top of {ERC7984} that allows shielding an `ERC20` token
+ * into an `ERC7984` token. The wrapper contract implements the `IERC1363Receiver` interface
+ * which allows users to transfer `ERC1363` tokens directly to the wrapper with a callback to shield the tokens.
+ *
+ * WARNING: Minting assumes the full amount of the underlying token transfer has been received, hence some non-standard
+ * tokens such as fee-on-transfer or other deflationary-type tokens are not supported by this wrapper.
+ */
+abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363Receiver {
+    IERC20 private immutable _underlying;
+
+    string private _wrappedName;
+    string private _wrappedSymbol;
+    uint8 private immutable _wrappedDecimals;
+    uint256 private immutable _rate;
+
+    mapping(bytes32 unshieldRequestId => address recipient) private _unshieldRequests;
+
+    error InvalidUnshieldRequest(bytes32 unshieldRequestId);
+    error ERC7984TotalSupplyOverflow();
+
+    event SymbolUpdated(string symbol);
+
+    constructor(IERC20 underlying_, string memory name_, string memory symbol_) {
+        _underlying = underlying_;
+        _wrappedName = name_;
+        _wrappedSymbol = symbol_;
+
+        uint8 tokenDecimals = _tryGetAssetDecimals(underlying_);
+        uint8 maxDecimals = _maxDecimals();
+        if (tokenDecimals > maxDecimals) {
+            _wrappedDecimals = maxDecimals;
+            _rate = 10 ** (tokenDecimals - maxDecimals);
+        } else {
+            _wrappedDecimals = tokenDecimals;
+            _rate = 1;
+        }
+    }
+
+    /// @dev Returns the name for this wrapped token.
+    function name() public view virtual override returns (string memory) {
+        return _wrappedName;
+    }
+
+    /// @dev Returns the symbol for this wrapped token (auto-generated or overridden at construction).
+    function symbol() public view virtual override returns (string memory) {
+        return _wrappedSymbol;
+    }
+
+    /**
+     * @dev Updates the symbol of this wrapped token.
+     *
+     * NOTE: Access control should be implemented by the inheriting contract.
+     */
+    function _updateSymbol(string memory updatedSymbol) internal virtual {
+        _wrappedSymbol = updatedSymbol;
+        emit SymbolUpdated(updatedSymbol);
+    }
+
+    /**
+     * @dev `ERC1363` callback function which shields tokens to the address specified in `data` or
+     * the address `from` (if no address is specified in `data`). This function refunds any excess tokens
+     * sent beyond the nearest multiple of {rate} to `from`. See {shield} for more details on shielding tokens.
+     */
+    function onTransferReceived(
+        address,
+        address from,
+        uint256 amount,
+        bytes calldata data
+    ) public virtual returns (bytes4) {
+        if (underlying() != msg.sender) revert ERC7984UnauthorizedCaller(msg.sender);
+
+        address to = data.length < 20 ? from : address(bytes20(data));
+        _mint(to, FHE.asEuint64(SafeCast.toUint64(amount / rate())));
+
+        uint256 excess = amount % rate();
+        if (excess > 0) SafeERC20.safeTransfer(IERC20(underlying()), from, excess);
+
+        return IERC1363Receiver.onTransferReceived.selector;
+    }
+
+    /**
+     * @dev See {IERC7984ERC20Wrapper-shield}. Tokens are exchanged at a fixed rate specified by {rate} such that
+     * `amount / rate()` confidential tokens are sent. The amount transferred in is rounded down to the nearest
+     * multiple of {rate}.
+     *
+     * Returns the amount of shielded token sent.
+     */
+    function shield(address to, uint256 amount) public virtual override returns (euint64) {
+        SafeERC20.safeTransferFrom(IERC20(underlying()), msg.sender, address(this), amount - (amount % rate()));
+
+        euint64 shieldedAmountSent = _mint(to, FHE.asEuint64(SafeCast.toUint64(amount / rate())));
+        FHE.allowTransient(shieldedAmountSent, msg.sender);
+
+        return shieldedAmountSent;
+    }
+
+    /// @dev Unshield without passing an input proof. See {unshield-address-address-InEuint64} for more details.
+    function unshield(address from, address to, euint64 amount) public virtual returns (bytes32) {
+        if (!FHE.isAllowed(amount, msg.sender)) revert ERC7984UnauthorizedUseOfEncryptedAmount(amount, msg.sender);
+        return _unshield(from, to, amount);
+    }
+
+    /**
+     * @dev See {IERC7984ERC20Wrapper-unshield}. `amount * rate()` underlying tokens will be sent to `to`
+     * once the unshield request is claimed via {claimUnshielded}.
+     *
+     * NOTE: The unshield request created by this function must be finalized by calling {claimUnshielded}.
+     */
+    function unshield(address from, address to, InEuint64 memory encryptedAmount) public virtual returns (bytes32) {
+        return _unshield(from, to, FHE.asEuint64(encryptedAmount));
+    }
+
+    /// @inheritdoc IERC7984ERC20Wrapper
+    function claimUnshielded(
+        bytes32 unshieldRequestId,
+        uint64 unshieldAmountCleartext,
+        bytes calldata decryptionProof
+    ) public virtual {
+        address to = unshieldRequester(unshieldRequestId);
+        if (to == address(0)) revert InvalidUnshieldRequest(unshieldRequestId);
+
+        euint64 unshieldAmount_ = unshieldAmount(unshieldRequestId);
+        delete _unshieldRequests[unshieldRequestId];
+
+        FHE.verifyDecryptResult(unshieldAmount_, unshieldAmountCleartext, decryptionProof);
+
+        SafeERC20.safeTransfer(IERC20(underlying()), to, unshieldAmountCleartext * rate());
+
+        emit ClaimedUnshielded(to, unshieldRequestId, unshieldAmount_, unshieldAmountCleartext);
+    }
+
+    /// @inheritdoc ERC7984
+    function decimals() public view virtual override returns (uint8) {
+        return _wrappedDecimals;
+    }
+
+    /// @inheritdoc IERC7984ERC20Wrapper
+    function rate() public view virtual returns (uint256) {
+        return _rate;
+    }
+
+    /// @inheritdoc IERC7984ERC20Wrapper
+    function underlying() public view virtual override returns (address) {
+        return address(_underlying);
+    }
+
+    /// @inheritdoc IERC7984ERC20Wrapper
+    function unshieldAmount(bytes32 unshieldRequestId) public view virtual returns (euint64) {
+        return euint64.wrap(unshieldRequestId);
+    }
+
+    /// @inheritdoc IERC165
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return
+            interfaceId == type(IERC7984ERC20Wrapper).interfaceId ||
+            interfaceId == type(IERC1363Receiver).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+
+    /**
+     * @dev Returns the underlying balance divided by the {rate}, a value greater or equal to the actual
+     * {confidentialTotalSupply}.
+     *
+     * NOTE: The return value of this function can be inflated by directly sending underlying tokens to the wrapper contract.
+     * Reductions will lag compared to {confidentialTotalSupply} since it is updated on {unshield} while this function updates
+     * on {claimUnshielded}.
+     */
+    function inferredTotalSupply() public view virtual returns (uint256) {
+        return IERC20(underlying()).balanceOf(address(this)) / rate();
+    }
+
+    /// @dev Returns the maximum total supply of shielded tokens supported by the encrypted datatype.
+    function maxTotalSupply() public view virtual returns (uint256) {
+        return type(uint64).max;
+    }
+
+    /**
+     * @dev Get the address that has a pending unshield request for the given `unshieldRequestId`.
+     * Returns `address(0)` if no pending unshield request exists.
+     */
+    function unshieldRequester(bytes32 unshieldRequestId) public view virtual returns (address) {
+        return _unshieldRequests[unshieldRequestId];
+    }
+
+    /**
+     * @dev This function must revert if the new {confidentialTotalSupply} is invalid (overflow occurred).
+     *
+     * NOTE: Overflow can be detected here since the wrapper holdings are non-confidential. In other cases, it may be impossible
+     * to infer total supply overflow synchronously. This function may revert even if the {confidentialTotalSupply} did
+     * not overflow.
+     */
+    function _checkConfidentialTotalSupply() internal virtual {
+        if (inferredTotalSupply() > maxTotalSupply()) {
+            revert ERC7984TotalSupplyOverflow();
+        }
+    }
+
+    /// @inheritdoc ERC7984
+    function _update(address from, address to, euint64 amount) internal virtual override returns (euint64) {
+        if (from == address(0)) {
+            _checkConfidentialTotalSupply();
+        }
+        return super._update(from, to, amount);
+    }
+
+    /// @dev Internal logic for handling the creation of unshield requests. Returns the unshield request id.
+    function _unshield(address from, address to, euint64 amount) internal virtual returns (bytes32) {
+        if (to == address(0)) revert ERC7984InvalidReceiver(to);
+        if (from != msg.sender && !isOperator(from, msg.sender)) revert ERC7984UnauthorizedSpender(from, msg.sender);
+
+        euint64 unshieldAmount_ = _burn(from, amount);
+        FHE.allowPublic(unshieldAmount_);
+
+        assert(unshieldRequester(euint64.unwrap(unshieldAmount_)) == address(0));
+
+        // WARNING: Directly using the cipher-text as the unshield request id assumes that
+        // cipher-texts are unique--this holds here but is not always true.
+        bytes32 unshieldRequestId = euint64.unwrap(unshieldAmount_);
+        _unshieldRequests[unshieldRequestId] = to;
+
+        emit Unshielded(to, unshieldRequestId, unshieldAmount_);
+        return unshieldRequestId;
+    }
+
+    /**
+     * @dev Returns the default number of decimals of the underlying ERC-20 token.
+     * Used as a fallback when {_tryGetAssetDecimals} fails.
+     */
+    function _fallbackUnderlyingDecimals() internal pure virtual returns (uint8) {
+        return 18;
+    }
+
+    /// @dev Returns the maximum number that will be used for {decimals} by the wrapper.
+    function _maxDecimals() internal pure virtual returns (uint8) {
+        return 6;
+    }
+
+    function _tryGetAssetDecimals(IERC20 asset_) private view returns (uint8 assetDecimals) {
+        (bool success, bytes memory encodedDecimals) = address(asset_).staticcall(
+            abi.encodeCall(IERC20Metadata.decimals, ())
+        );
+        if (success && encodedDecimals.length == 32) {
+            return abi.decode(encodedDecimals, (uint8));
+        }
+        return _fallbackUnderlyingDecimals();
+    }
+}

--- a/contracts/ERC7984/extensions/ERC7984ERC20Wrapper.sol
+++ b/contracts/ERC7984/extensions/ERC7984ERC20Wrapper.sol
@@ -1,16 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { FHE, euint64, InEuint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+import { FHE, euint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+
 import { IERC1363Receiver } from "@openzeppelin/contracts/interfaces/IERC1363Receiver.sol";
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 import { IERC20Metadata } from "@openzeppelin/contracts/interfaces/IERC20Metadata.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
-import { IERC7984 } from "../../interfaces/IERC7984.sol";
 import { IERC7984ERC20Wrapper } from "../../interfaces/IERC7984ERC20Wrapper.sol";
 import { ERC7984 } from "../ERC7984.sol";
+import { ERC7984WrapperClaimHelper } from "../utils/ERC7984WrapperClaimHelper.sol";
 
 /**
  * @dev A wrapper contract built on top of {ERC7984} that allows shielding an `ERC20` token
@@ -20,25 +21,15 @@ import { ERC7984 } from "../ERC7984.sol";
  * WARNING: Minting assumes the full amount of the underlying token transfer has been received, hence some non-standard
  * tokens such as fee-on-transfer or other deflationary-type tokens are not supported by this wrapper.
  */
-abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363Receiver {
+abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363Receiver, ERC7984WrapperClaimHelper {
     IERC20 private immutable _underlying;
-
-    string private _wrappedName;
-    string private _wrappedSymbol;
     uint8 private immutable _wrappedDecimals;
     uint256 private immutable _rate;
 
-    mapping(bytes32 unshieldRequestId => address recipient) private _unshieldRequests;
-
-    error InvalidUnshieldRequest(bytes32 unshieldRequestId);
     error ERC7984TotalSupplyOverflow();
 
-    event SymbolUpdated(string symbol);
-
-    constructor(IERC20 underlying_, string memory name_, string memory symbol_) {
+    constructor(IERC20 underlying_) {
         _underlying = underlying_;
-        _wrappedName = name_;
-        _wrappedSymbol = symbol_;
 
         uint8 tokenDecimals = _tryGetAssetDecimals(underlying_);
         uint8 maxDecimals = _maxDecimals();
@@ -49,26 +40,6 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
             _wrappedDecimals = tokenDecimals;
             _rate = 1;
         }
-    }
-
-    /// @dev Returns the name for this wrapped token.
-    function name() public view virtual override returns (string memory) {
-        return _wrappedName;
-    }
-
-    /// @dev Returns the symbol for this wrapped token (auto-generated or overridden at construction).
-    function symbol() public view virtual override returns (string memory) {
-        return _wrappedSymbol;
-    }
-
-    /**
-     * @dev Updates the symbol of this wrapped token.
-     *
-     * NOTE: Access control should be implemented by the inheriting contract.
-     */
-    function _updateSymbol(string memory updatedSymbol) internal virtual {
-        _wrappedSymbol = updatedSymbol;
-        emit SymbolUpdated(updatedSymbol);
     }
 
     /**
@@ -109,39 +80,49 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
         return shieldedAmountSent;
     }
 
-    /// @dev Unshield without passing an input proof. See {unshield-address-address-InEuint64} for more details.
-    function unshield(address from, address to, euint64 amount) public virtual returns (bytes32) {
-        if (!FHE.isAllowed(amount, msg.sender)) revert ERC7984UnauthorizedUseOfEncryptedAmount(amount, msg.sender);
-        return _unshield(from, to, amount);
+    /**
+     * @dev Initiates an unshield of `amount` confidential tokens from `from`, creating a pending
+     * claim for `to`. The caller must be `from` or an operator for `from`.
+     *
+     * Returns the encrypted amount that was burned (used as the claim's cipher-text handle).
+     */
+    function unshield(address from, address to, uint64 amount) public virtual returns (euint64) {
+        if (to == address(0)) revert ERC7984InvalidReceiver(to);
+        if (from != msg.sender && !isOperator(from, msg.sender)) revert ERC7984UnauthorizedSpender(from, msg.sender);
+
+        euint64 unshieldAmount_ = _burn(from, FHE.asEuint64(amount));
+        FHE.allowPublic(unshieldAmount_);
+
+        _createClaim(to, amount, unshieldAmount_);
+
+        emit Unshielded(to, unshieldAmount_);
+        return unshieldAmount_;
     }
 
     /**
-     * @dev See {IERC7984ERC20Wrapper-unshield}. `amount * rate()` underlying tokens will be sent to `to`
-     * once the unshield request is claimed via {claimUnshielded}.
-     *
-     * NOTE: The unshield request created by this function must be finalized by calling {claimUnshielded}.
+     * @dev Claims a pending unshield request. Verifies the decryption proof and transfers
+     * `decryptedAmount * rate()` underlying tokens to the requester.
      */
-    function unshield(address from, address to, InEuint64 memory encryptedAmount) public virtual returns (bytes32) {
-        return _unshield(from, to, FHE.asEuint64(encryptedAmount));
+    function claimUnshielded(bytes32 ctHash, uint64 decryptedAmount, bytes memory decryptionProof) public virtual {
+        Claim memory claim = _handleClaim(ctHash, decryptedAmount, decryptionProof);
+        SafeERC20.safeTransfer(IERC20(underlying()), claim.to, uint256(claim.decryptedAmount) * rate());
+        emit ClaimedUnshielded(claim.to, ctHash, euint64.wrap(ctHash), claim.decryptedAmount);
     }
 
-    /// @inheritdoc IERC7984ERC20Wrapper
-    function claimUnshielded(
-        bytes32 unshieldRequestId,
-        uint64 unshieldAmountCleartext,
-        bytes calldata decryptionProof
+    /**
+     * @dev Claims multiple pending unshield requests in a single transaction.
+     */
+    function claimUnshieldedBatch(
+        bytes32[] memory ctHashes,
+        uint64[] memory decryptedAmounts,
+        bytes[] memory decryptionProofs
     ) public virtual {
-        address to = unshieldRequester(unshieldRequestId);
-        if (to == address(0)) revert InvalidUnshieldRequest(unshieldRequestId);
+        Claim[] memory claims = _handleClaimBatch(ctHashes, decryptedAmounts, decryptionProofs);
 
-        euint64 unshieldAmount_ = unshieldAmount(unshieldRequestId);
-        delete _unshieldRequests[unshieldRequestId];
-
-        FHE.verifyDecryptResult(unshieldAmount_, unshieldAmountCleartext, decryptionProof);
-
-        SafeERC20.safeTransfer(IERC20(underlying()), to, unshieldAmountCleartext * rate());
-
-        emit ClaimedUnshielded(to, unshieldRequestId, unshieldAmount_, unshieldAmountCleartext);
+        for (uint256 i = 0; i < claims.length; i++) {
+            SafeERC20.safeTransfer(IERC20(underlying()), claims[i].to, uint256(claims[i].decryptedAmount) * rate());
+            emit ClaimedUnshielded(claims[i].to, ctHashes[i], euint64.wrap(ctHashes[i]), claims[i].decryptedAmount);
+        }
     }
 
     /// @inheritdoc ERC7984
@@ -157,11 +138,6 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
     /// @inheritdoc IERC7984ERC20Wrapper
     function underlying() public view virtual override returns (address) {
         return address(_underlying);
-    }
-
-    /// @inheritdoc IERC7984ERC20Wrapper
-    function unshieldAmount(bytes32 unshieldRequestId) public view virtual returns (euint64) {
-        return euint64.wrap(unshieldRequestId);
     }
 
     /// @inheritdoc IERC165
@@ -190,14 +166,6 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
     }
 
     /**
-     * @dev Get the address that has a pending unshield request for the given `unshieldRequestId`.
-     * Returns `address(0)` if no pending unshield request exists.
-     */
-    function unshieldRequester(bytes32 unshieldRequestId) public view virtual returns (address) {
-        return _unshieldRequests[unshieldRequestId];
-    }
-
-    /**
      * @dev This function must revert if the new {confidentialTotalSupply} is invalid (overflow occurred).
      *
      * NOTE: Overflow can be detected here since the wrapper holdings are non-confidential. In other cases, it may be impossible
@@ -216,25 +184,6 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
             _checkConfidentialTotalSupply();
         }
         return super._update(from, to, amount);
-    }
-
-    /// @dev Internal logic for handling the creation of unshield requests. Returns the unshield request id.
-    function _unshield(address from, address to, euint64 amount) internal virtual returns (bytes32) {
-        if (to == address(0)) revert ERC7984InvalidReceiver(to);
-        if (from != msg.sender && !isOperator(from, msg.sender)) revert ERC7984UnauthorizedSpender(from, msg.sender);
-
-        euint64 unshieldAmount_ = _burn(from, amount);
-        FHE.allowPublic(unshieldAmount_);
-
-        assert(unshieldRequester(euint64.unwrap(unshieldAmount_)) == address(0));
-
-        // WARNING: Directly using the cipher-text as the unshield request id assumes that
-        // cipher-texts are unique--this holds here but is not always true.
-        bytes32 unshieldRequestId = euint64.unwrap(unshieldAmount_);
-        _unshieldRequests[unshieldRequestId] = to;
-
-        emit Unshielded(to, unshieldRequestId, unshieldAmount_);
-        return unshieldRequestId;
     }
 
     /**

--- a/contracts/ERC7984/extensions/ERC7984ERC20Wrapper.sol
+++ b/contracts/ERC7984/extensions/ERC7984ERC20Wrapper.sol
@@ -106,7 +106,7 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
     function claimUnshielded(bytes32 ctHash, uint64 decryptedAmount, bytes memory decryptionProof) public virtual {
         Claim memory claim = _handleClaim(ctHash, decryptedAmount, decryptionProof);
         SafeERC20.safeTransfer(IERC20(underlying()), claim.to, uint256(claim.decryptedAmount) * rate());
-        emit ClaimedUnshielded(claim.to, ctHash, euint64.wrap(ctHash), claim.decryptedAmount);
+        emit ClaimedUnshielded(claim.to, ctHash, FHE.wrapEuint64(ctHash), claim.decryptedAmount);
     }
 
     /**
@@ -121,7 +121,7 @@ abstract contract ERC7984ERC20Wrapper is ERC7984, IERC7984ERC20Wrapper, IERC1363
 
         for (uint256 i = 0; i < claims.length; i++) {
             SafeERC20.safeTransfer(IERC20(underlying()), claims[i].to, uint256(claims[i].decryptedAmount) * rate());
-            emit ClaimedUnshielded(claims[i].to, ctHashes[i], euint64.wrap(ctHashes[i]), claims[i].decryptedAmount);
+            emit ClaimedUnshielded(claims[i].to, ctHashes[i], FHE.wrapEuint64(ctHashes[i]), claims[i].decryptedAmount);
         }
     }
 

--- a/contracts/ERC7984/extensions/ERC7984NativeWrapper.sol
+++ b/contracts/ERC7984/extensions/ERC7984NativeWrapper.sol
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { FHE, euint64, InEuint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+import { IERC20Metadata } from "@openzeppelin/contracts/interfaces/IERC20Metadata.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import { IERC7984NativeWrapper } from "../../interfaces/IERC7984NativeWrapper.sol";
+import { IWETH } from "../../interfaces/IWETH.sol";
+import { ERC7984 } from "../ERC7984.sol";
+
+/**
+ * @dev A wrapper contract built on top of {ERC7984} that shields a chain's native token
+ * (e.g. ETH) into a confidential {ERC7984} token.
+ *
+ * Two shield entry-points are provided:
+ *  - {shieldWrappedNative}: pulls WETH from the caller, unwraps it to native, and mints
+ *    confidential tokens.
+ *  - {shieldNative}: accepts native value directly and mints confidential tokens.
+ *    Any dust below the conversion rate is refunded to the caller.
+ *
+ * Confidential precision is capped at {_maxDecimals} (default 6). For 18-decimal native
+ * tokens the conversion rate is 1e12, so 1 native unit = 1e-6 confidential units.
+ */
+abstract contract ERC7984NativeWrapper is ERC7984, IERC7984NativeWrapper {
+    using SafeERC20 for IWETH;
+
+    IWETH private immutable _weth;
+    uint8 private immutable _wrappedDecimals;
+    uint256 private immutable _rate;
+
+    string private _wrappedName;
+    string private _wrappedSymbol;
+
+    mapping(bytes32 unshieldRequestId => address recipient) private _unshieldRequests;
+
+    error InvalidUnshieldRequest(bytes32 unshieldRequestId);
+    error ERC7984TotalSupplyOverflow();
+    error NativeTransferFailed();
+    error AmountTooSmallForConfidentialPrecision();
+
+    event SymbolUpdated(string symbol);
+
+    constructor(IWETH weth_, string memory name_, string memory symbol_) {
+        _weth = weth_;
+
+        _wrappedName = name_;
+        _wrappedSymbol = symbol_;
+
+        uint8 tokenDecimals = IERC20Metadata(address(weth_)).decimals();
+        uint8 maxDecimals = _maxDecimals();
+        if (tokenDecimals > maxDecimals) {
+            _wrappedDecimals = maxDecimals;
+            _rate = 10 ** (tokenDecimals - maxDecimals);
+        } else {
+            _wrappedDecimals = tokenDecimals;
+            _rate = 1;
+        }
+    }
+
+    receive() external payable {}
+
+    /// @dev Returns the name for this wrapped native token.
+    function name() public view virtual override returns (string memory) {
+        return _wrappedName;
+    }
+
+    /// @dev Returns the symbol for this wrapped native token.
+    function symbol() public view virtual override returns (string memory) {
+        return _wrappedSymbol;
+    }
+
+    /**
+     * @dev Updates the symbol of this wrapped token.
+     *
+     * NOTE: Access control should be implemented by the inheriting contract.
+     */
+    function _updateSymbol(string memory updatedSymbol) internal virtual {
+        _wrappedSymbol = updatedSymbol;
+        emit SymbolUpdated(updatedSymbol);
+    }
+
+    /// @inheritdoc IERC7984NativeWrapper
+    function shieldWrappedNative(address to, uint256 value) public virtual returns (euint64) {
+        if (to == address(0)) to = msg.sender;
+
+        uint256 alignedValue = value - (value % rate());
+        if (alignedValue == 0) revert AmountTooSmallForConfidentialPrecision();
+
+        uint64 confidentialAmount = SafeCast.toUint64(alignedValue / rate());
+
+        _weth.safeTransferFrom(msg.sender, address(this), alignedValue);
+        _weth.withdraw(alignedValue);
+
+        euint64 shieldedAmountSent = _mint(to, FHE.asEuint64(confidentialAmount));
+        FHE.allowTransient(shieldedAmountSent, msg.sender);
+
+        emit ShieldedNative(msg.sender, to, alignedValue);
+        return shieldedAmountSent;
+    }
+
+    /// @inheritdoc IERC7984NativeWrapper
+    function shieldNative(address to) public payable virtual returns (euint64) {
+        if (to == address(0)) to = msg.sender;
+
+        uint256 alignedValue = msg.value - (msg.value % rate());
+        if (alignedValue == 0) revert AmountTooSmallForConfidentialPrecision();
+
+        uint256 dust = msg.value - alignedValue;
+        if (dust > 0) {
+            (bool refunded, ) = msg.sender.call{ value: dust }("");
+            if (!refunded) revert NativeTransferFailed();
+        }
+
+        uint64 confidentialAmount = SafeCast.toUint64(alignedValue / rate());
+
+        euint64 shieldedAmountSent = _mint(to, FHE.asEuint64(confidentialAmount));
+        FHE.allowTransient(shieldedAmountSent, msg.sender);
+
+        emit ShieldedNative(msg.sender, to, alignedValue);
+        return shieldedAmountSent;
+    }
+
+    /// @dev Unshield without passing an input proof. See {unshield-address-address-InEuint64} for more details.
+    function unshield(address from, address to, euint64 amount) public virtual returns (bytes32) {
+        if (!FHE.isAllowed(amount, msg.sender)) revert ERC7984UnauthorizedUseOfEncryptedAmount(amount, msg.sender);
+        return _unshield(from, to, amount);
+    }
+
+    /**
+     * @dev See {IERC7984NativeWrapper-unshield}. `amount * rate()` native tokens will be sent to `to`
+     * once the unshield request is claimed via {claimUnshielded}.
+     *
+     * NOTE: The unshield request created by this function must be finalized by calling {claimUnshielded}.
+     */
+    function unshield(address from, address to, InEuint64 memory encryptedAmount) public virtual returns (bytes32) {
+        return _unshield(from, to, FHE.asEuint64(encryptedAmount));
+    }
+
+    /// @inheritdoc IERC7984NativeWrapper
+    function claimUnshielded(
+        bytes32 unshieldRequestId,
+        uint64 unshieldAmountCleartext,
+        bytes calldata decryptionProof
+    ) public virtual {
+        address to = unshieldRequester(unshieldRequestId);
+        if (to == address(0)) revert InvalidUnshieldRequest(unshieldRequestId);
+
+        euint64 unshieldAmount_ = unshieldAmount(unshieldRequestId);
+        delete _unshieldRequests[unshieldRequestId];
+
+        FHE.verifyDecryptResult(unshieldAmount_, unshieldAmountCleartext, decryptionProof);
+
+        uint256 nativeAmount = uint256(unshieldAmountCleartext) * rate();
+        (bool sent, ) = to.call{ value: nativeAmount }("");
+        if (!sent) revert NativeTransferFailed();
+
+        emit ClaimedUnshielded(to, unshieldRequestId, unshieldAmount_, unshieldAmountCleartext);
+    }
+
+    /// @inheritdoc ERC7984
+    function decimals() public view virtual override returns (uint8) {
+        return _wrappedDecimals;
+    }
+
+    /// @inheritdoc IERC7984NativeWrapper
+    function rate() public view virtual returns (uint256) {
+        return _rate;
+    }
+
+    /// @inheritdoc IERC7984NativeWrapper
+    function weth() public view virtual returns (address) {
+        return address(_weth);
+    }
+
+    /// @inheritdoc IERC7984NativeWrapper
+    function unshieldAmount(bytes32 unshieldRequestId) public view virtual returns (euint64) {
+        return euint64.wrap(unshieldRequestId);
+    }
+
+    /// @inheritdoc IERC165
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return
+            interfaceId == type(IERC7984NativeWrapper).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+
+    /**
+     * @dev Returns the native balance held by this contract divided by the {rate},
+     * a value greater or equal to the actual {confidentialTotalSupply}.
+     *
+     * NOTE: The return value can be inflated by directly sending native tokens to the contract.
+     * Reductions will lag compared to {confidentialTotalSupply} since it is updated on {unshield}
+     * while this function updates on {claimUnshielded}.
+     */
+    function inferredTotalSupply() public view virtual returns (uint256) {
+        return address(this).balance / rate();
+    }
+
+    /// @dev Returns the maximum total supply of shielded tokens supported by the encrypted datatype.
+    function maxTotalSupply() public view virtual returns (uint256) {
+        return type(uint64).max;
+    }
+
+    /**
+     * @dev Get the address that has a pending unshield request for the given `unshieldRequestId`.
+     * Returns `address(0)` if no pending unshield request exists.
+     */
+    function unshieldRequester(bytes32 unshieldRequestId) public view virtual returns (address) {
+        return _unshieldRequests[unshieldRequestId];
+    }
+
+    /**
+     * @dev This function must revert if the new {confidentialTotalSupply} is invalid (overflow occurred).
+     *
+     * NOTE: Overflow can be detected here since the native balance is non-confidential.
+     * This function may revert even if the {confidentialTotalSupply} did not overflow.
+     */
+    function _checkConfidentialTotalSupply() internal virtual {
+        if (inferredTotalSupply() > maxTotalSupply()) {
+            revert ERC7984TotalSupplyOverflow();
+        }
+    }
+
+    /// @inheritdoc ERC7984
+    function _update(address from, address to, euint64 amount) internal virtual override returns (euint64) {
+        if (from == address(0)) {
+            _checkConfidentialTotalSupply();
+        }
+        return super._update(from, to, amount);
+    }
+
+    /// @dev Internal logic for handling the creation of unshield requests. Returns the unshield request id.
+    function _unshield(address from, address to, euint64 amount) internal virtual returns (bytes32) {
+        if (to == address(0)) revert ERC7984InvalidReceiver(to);
+        if (from != msg.sender && !isOperator(from, msg.sender)) revert ERC7984UnauthorizedSpender(from, msg.sender);
+
+        euint64 unshieldAmount_ = _burn(from, amount);
+        FHE.allowPublic(unshieldAmount_);
+
+        assert(unshieldRequester(euint64.unwrap(unshieldAmount_)) == address(0));
+
+        bytes32 unshieldRequestId = euint64.unwrap(unshieldAmount_);
+        _unshieldRequests[unshieldRequestId] = to;
+
+        emit Unshielded(to, unshieldRequestId, unshieldAmount_);
+        return unshieldRequestId;
+    }
+
+    /// @dev Returns the maximum number that will be used for {decimals} by the wrapper.
+    function _maxDecimals() internal pure virtual returns (uint8) {
+        return 6;
+    }
+}

--- a/contracts/ERC7984/extensions/ERC7984NativeWrapper.sol
+++ b/contracts/ERC7984/extensions/ERC7984NativeWrapper.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { FHE, euint64, InEuint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+import { FHE, euint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
 import { IERC20Metadata } from "@openzeppelin/contracts/interfaces/IERC20Metadata.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
@@ -9,6 +9,7 @@ import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { IERC7984NativeWrapper } from "../../interfaces/IERC7984NativeWrapper.sol";
 import { IWETH } from "../../interfaces/IWETH.sol";
 import { ERC7984 } from "../ERC7984.sol";
+import { ERC7984WrapperClaimHelper } from "../utils/ERC7984WrapperClaimHelper.sol";
 
 /**
  * @dev A wrapper contract built on top of {ERC7984} that shields a chain's native token
@@ -23,30 +24,19 @@ import { ERC7984 } from "../ERC7984.sol";
  * Confidential precision is capped at {_maxDecimals} (default 6). For 18-decimal native
  * tokens the conversion rate is 1e12, so 1 native unit = 1e-6 confidential units.
  */
-abstract contract ERC7984NativeWrapper is ERC7984, IERC7984NativeWrapper {
+abstract contract ERC7984NativeWrapper is ERC7984, IERC7984NativeWrapper, ERC7984WrapperClaimHelper {
     using SafeERC20 for IWETH;
 
     IWETH private immutable _weth;
     uint8 private immutable _wrappedDecimals;
     uint256 private immutable _rate;
 
-    string private _wrappedName;
-    string private _wrappedSymbol;
-
-    mapping(bytes32 unshieldRequestId => address recipient) private _unshieldRequests;
-
-    error InvalidUnshieldRequest(bytes32 unshieldRequestId);
     error ERC7984TotalSupplyOverflow();
     error NativeTransferFailed();
     error AmountTooSmallForConfidentialPrecision();
 
-    event SymbolUpdated(string symbol);
-
-    constructor(IWETH weth_, string memory name_, string memory symbol_) {
+    constructor(IWETH weth_) {
         _weth = weth_;
-
-        _wrappedName = name_;
-        _wrappedSymbol = symbol_;
 
         uint8 tokenDecimals = IERC20Metadata(address(weth_)).decimals();
         uint8 maxDecimals = _maxDecimals();
@@ -60,26 +50,6 @@ abstract contract ERC7984NativeWrapper is ERC7984, IERC7984NativeWrapper {
     }
 
     receive() external payable {}
-
-    /// @dev Returns the name for this wrapped native token.
-    function name() public view virtual override returns (string memory) {
-        return _wrappedName;
-    }
-
-    /// @dev Returns the symbol for this wrapped native token.
-    function symbol() public view virtual override returns (string memory) {
-        return _wrappedSymbol;
-    }
-
-    /**
-     * @dev Updates the symbol of this wrapped token.
-     *
-     * NOTE: Access control should be implemented by the inheriting contract.
-     */
-    function _updateSymbol(string memory updatedSymbol) internal virtual {
-        _wrappedSymbol = updatedSymbol;
-        emit SymbolUpdated(updatedSymbol);
-    }
 
     /// @inheritdoc IERC7984NativeWrapper
     function shieldWrappedNative(address to, uint256 value) public virtual returns (euint64) {
@@ -122,41 +92,59 @@ abstract contract ERC7984NativeWrapper is ERC7984, IERC7984NativeWrapper {
         return shieldedAmountSent;
     }
 
-    /// @dev Unshield without passing an input proof. See {unshield-address-address-InEuint64} for more details.
-    function unshield(address from, address to, euint64 amount) public virtual returns (bytes32) {
-        if (!FHE.isAllowed(amount, msg.sender)) revert ERC7984UnauthorizedUseOfEncryptedAmount(amount, msg.sender);
-        return _unshield(from, to, amount);
+    /**
+     * @dev Initiates an unshield of `amount` confidential tokens from `from`, creating a pending
+     * claim for `to`. The caller must be `from` or an operator for `from`.
+     *
+     * Returns the encrypted amount that was burned (used as the claim's cipher-text handle).
+     */
+    function unshield(address from, address to, uint64 amount) public virtual returns (euint64) {
+        if (to == address(0)) revert ERC7984InvalidReceiver(to);
+        if (from != msg.sender && !isOperator(from, msg.sender)) revert ERC7984UnauthorizedSpender(from, msg.sender);
+
+        euint64 unshieldAmount_ = _burn(from, FHE.asEuint64(amount));
+        FHE.allowPublic(unshieldAmount_);
+
+        _createClaim(to, amount, unshieldAmount_);
+
+        emit Unshielded(to, unshieldAmount_);
+        return unshieldAmount_;
     }
 
     /**
-     * @dev See {IERC7984NativeWrapper-unshield}. `amount * rate()` native tokens will be sent to `to`
-     * once the unshield request is claimed via {claimUnshielded}.
-     *
-     * NOTE: The unshield request created by this function must be finalized by calling {claimUnshielded}.
+     * @dev Claims a pending unshield request. Verifies the decryption proof and transfers
+     * `decryptedAmount * rate()` native tokens to the requester.
      */
-    function unshield(address from, address to, InEuint64 memory encryptedAmount) public virtual returns (bytes32) {
-        return _unshield(from, to, FHE.asEuint64(encryptedAmount));
-    }
-
-    /// @inheritdoc IERC7984NativeWrapper
     function claimUnshielded(
-        bytes32 unshieldRequestId,
-        uint64 unshieldAmountCleartext,
-        bytes calldata decryptionProof
+        bytes32 ctHash,
+        uint64 decryptedAmount,
+        bytes memory decryptionProof
     ) public virtual {
-        address to = unshieldRequester(unshieldRequestId);
-        if (to == address(0)) revert InvalidUnshieldRequest(unshieldRequestId);
+        Claim memory claim = _handleClaim(ctHash, decryptedAmount, decryptionProof);
 
-        euint64 unshieldAmount_ = unshieldAmount(unshieldRequestId);
-        delete _unshieldRequests[unshieldRequestId];
-
-        FHE.verifyDecryptResult(unshieldAmount_, unshieldAmountCleartext, decryptionProof);
-
-        uint256 nativeAmount = uint256(unshieldAmountCleartext) * rate();
-        (bool sent, ) = to.call{ value: nativeAmount }("");
+        uint256 nativeAmount = uint256(claim.decryptedAmount) * rate();
+        (bool sent, ) = claim.to.call{ value: nativeAmount }("");
         if (!sent) revert NativeTransferFailed();
 
-        emit ClaimedUnshielded(to, unshieldRequestId, unshieldAmount_, unshieldAmountCleartext);
+        emit ClaimedUnshielded(claim.to, ctHash, euint64.wrap(ctHash), claim.decryptedAmount);
+    }
+
+    /**
+     * @dev Claims multiple pending unshield requests in a single transaction.
+     */
+    function claimUnshieldedBatch(
+        bytes32[] memory ctHashes,
+        uint64[] memory decryptedAmounts,
+        bytes[] memory decryptionProofs
+    ) public virtual {
+        Claim[] memory claims = _handleClaimBatch(ctHashes, decryptedAmounts, decryptionProofs);
+
+        for (uint256 i = 0; i < claims.length; i++) {
+            uint256 nativeAmount = uint256(claims[i].decryptedAmount) * rate();
+            (bool sent, ) = claims[i].to.call{ value: nativeAmount }("");
+            if (!sent) revert NativeTransferFailed();
+            emit ClaimedUnshielded(claims[i].to, ctHashes[i], euint64.wrap(ctHashes[i]), claims[i].decryptedAmount);
+        }
     }
 
     /// @inheritdoc ERC7984
@@ -172,11 +160,6 @@ abstract contract ERC7984NativeWrapper is ERC7984, IERC7984NativeWrapper {
     /// @inheritdoc IERC7984NativeWrapper
     function weth() public view virtual returns (address) {
         return address(_weth);
-    }
-
-    /// @inheritdoc IERC7984NativeWrapper
-    function unshieldAmount(bytes32 unshieldRequestId) public view virtual returns (euint64) {
-        return euint64.wrap(unshieldRequestId);
     }
 
     /// @inheritdoc IERC165
@@ -204,14 +187,6 @@ abstract contract ERC7984NativeWrapper is ERC7984, IERC7984NativeWrapper {
     }
 
     /**
-     * @dev Get the address that has a pending unshield request for the given `unshieldRequestId`.
-     * Returns `address(0)` if no pending unshield request exists.
-     */
-    function unshieldRequester(bytes32 unshieldRequestId) public view virtual returns (address) {
-        return _unshieldRequests[unshieldRequestId];
-    }
-
-    /**
      * @dev This function must revert if the new {confidentialTotalSupply} is invalid (overflow occurred).
      *
      * NOTE: Overflow can be detected here since the native balance is non-confidential.
@@ -229,23 +204,6 @@ abstract contract ERC7984NativeWrapper is ERC7984, IERC7984NativeWrapper {
             _checkConfidentialTotalSupply();
         }
         return super._update(from, to, amount);
-    }
-
-    /// @dev Internal logic for handling the creation of unshield requests. Returns the unshield request id.
-    function _unshield(address from, address to, euint64 amount) internal virtual returns (bytes32) {
-        if (to == address(0)) revert ERC7984InvalidReceiver(to);
-        if (from != msg.sender && !isOperator(from, msg.sender)) revert ERC7984UnauthorizedSpender(from, msg.sender);
-
-        euint64 unshieldAmount_ = _burn(from, amount);
-        FHE.allowPublic(unshieldAmount_);
-
-        assert(unshieldRequester(euint64.unwrap(unshieldAmount_)) == address(0));
-
-        bytes32 unshieldRequestId = euint64.unwrap(unshieldAmount_);
-        _unshieldRequests[unshieldRequestId] = to;
-
-        emit Unshielded(to, unshieldRequestId, unshieldAmount_);
-        return unshieldRequestId;
     }
 
     /// @dev Returns the maximum number that will be used for {decimals} by the wrapper.

--- a/contracts/ERC7984/extensions/ERC7984NativeWrapper.sol
+++ b/contracts/ERC7984/extensions/ERC7984NativeWrapper.sol
@@ -126,7 +126,7 @@ abstract contract ERC7984NativeWrapper is ERC7984, IERC7984NativeWrapper, ERC798
         (bool sent, ) = claim.to.call{ value: nativeAmount }("");
         if (!sent) revert NativeTransferFailed();
 
-        emit ClaimedUnshielded(claim.to, ctHash, euint64.wrap(ctHash), claim.decryptedAmount);
+        emit ClaimedUnshielded(claim.to, ctHash, FHE.wrapEuint64(ctHash), claim.decryptedAmount);
     }
 
     /**
@@ -143,7 +143,7 @@ abstract contract ERC7984NativeWrapper is ERC7984, IERC7984NativeWrapper, ERC798
             uint256 nativeAmount = uint256(claims[i].decryptedAmount) * rate();
             (bool sent, ) = claims[i].to.call{ value: nativeAmount }("");
             if (!sent) revert NativeTransferFailed();
-            emit ClaimedUnshielded(claims[i].to, ctHashes[i], euint64.wrap(ctHashes[i]), claims[i].decryptedAmount);
+            emit ClaimedUnshielded(claims[i].to, ctHashes[i], FHE.wrapEuint64(ctHashes[i]), claims[i].decryptedAmount);
         }
     }
 

--- a/contracts/ERC7984/utils/ERC7984Utils.sol
+++ b/contracts/ERC7984/utils/ERC7984Utils.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { FHE, ebool, euint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+
+import { IERC7984Receiver } from "../../interfaces/IERC7984Receiver.sol";
+import { ERC7984 } from "../ERC7984.sol";
+
+/// @dev Library that provides common {ERC7984} utility functions.
+library ERC7984Utils {
+    /**
+     * @dev Performs a transfer callback to the recipient of the transfer `to`. Should be invoked
+     * after all transfers "withCallback" on a {ERC7984}.
+     *
+     * The transfer callback is not invoked on the recipient if the recipient has no code (i.e. is an EOA). If the
+     * recipient has non-zero code, it must implement
+     * {IERC7984Receiver-onConfidentialTransferReceived} and return an `ebool` indicating
+     * whether the transfer was accepted or not. If the `ebool` is `false`, the transfer function
+     * should try to refund the `from` address.
+     */
+    function checkOnTransferReceived(
+        address operator,
+        address from,
+        address to,
+        euint64 amount,
+        bytes calldata data
+    ) internal returns (ebool) {
+        if (to.code.length > 0) {
+            try IERC7984Receiver(to).onConfidentialTransferReceived(operator, from, amount, data) returns (
+                ebool retval
+            ) {
+                return retval;
+            } catch (bytes memory reason) {
+                if (reason.length == 0) {
+                    revert ERC7984.ERC7984InvalidReceiver(to);
+                } else {
+                    assembly ("memory-safe") {
+                        revert(add(32, reason), mload(reason))
+                    }
+                }
+            }
+        } else {
+            return FHE.asEbool(true);
+        }
+    }
+}

--- a/contracts/ERC7984/utils/ERC7984WrapperClaimHelper.sol
+++ b/contracts/ERC7984/utils/ERC7984WrapperClaimHelper.sol
@@ -30,7 +30,7 @@ abstract contract ERC7984WrapperClaimHelper {
     error LengthMismatch();
 
     function _createClaim(address to, uint64 requestedAmount, euint64 claimable) internal {
-        bytes32 unwrappedHash = euint64.unwrap(claimable);
+        bytes32 unwrappedHash = FHE.unwrap(claimable);
         _claims[unwrappedHash] = Claim({
             to: to,
             ctHash: unwrappedHash,
@@ -51,7 +51,7 @@ abstract contract ERC7984WrapperClaimHelper {
         if (claim.to == address(0)) revert ClaimNotFound();
         if (claim.claimed) revert AlreadyClaimed();
 
-        FHE.verifyDecryptResult(euint64.wrap(ctHash), decryptedAmount, decryptionProof);
+        FHE.verifyDecryptResult(FHE.wrapEuint64(ctHash), decryptedAmount, decryptionProof);
 
         claim.decryptedAmount = decryptedAmount;
         claim.claimed = true;

--- a/contracts/ERC7984/utils/ERC7984WrapperClaimHelper.sol
+++ b/contracts/ERC7984/utils/ERC7984WrapperClaimHelper.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { FHE, euint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+
+import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+
+/**
+ * @dev Abstract helper contract that manages pending unshield claims for {ERC7984} wrapper contracts.
+ *
+ * Provides claim lifecycle management: creation, single/batch handling (with decryption verification),
+ * and view functions for querying claim status.
+ */
+abstract contract ERC7984WrapperClaimHelper {
+    using EnumerableSet for EnumerableSet.Bytes32Set;
+
+    struct Claim {
+        address to;
+        bytes32 ctHash;
+        uint64 requestedAmount;
+        uint64 decryptedAmount;
+        bool claimed;
+    }
+
+    mapping(bytes32 ctHash => Claim) private _claims;
+    mapping(address => EnumerableSet.Bytes32Set) private _userClaims;
+
+    error ClaimNotFound();
+    error AlreadyClaimed();
+    error LengthMismatch();
+
+    function _createClaim(address to, uint64 requestedAmount, euint64 claimable) internal {
+        bytes32 unwrappedHash = euint64.unwrap(claimable);
+        _claims[unwrappedHash] = Claim({
+            to: to,
+            ctHash: unwrappedHash,
+            requestedAmount: requestedAmount,
+            decryptedAmount: 0,
+            claimed: false
+        });
+        _userClaims[to].add(unwrappedHash);
+    }
+
+    function _handleClaim(
+        bytes32 ctHash,
+        uint64 decryptedAmount,
+        bytes memory decryptionProof
+    ) internal returns (Claim memory claim) {
+        claim = _claims[ctHash];
+
+        if (claim.to == address(0)) revert ClaimNotFound();
+        if (claim.claimed) revert AlreadyClaimed();
+
+        FHE.verifyDecryptResult(euint64.wrap(ctHash), decryptedAmount, decryptionProof);
+
+        claim.decryptedAmount = decryptedAmount;
+        claim.claimed = true;
+
+        _claims[ctHash] = claim;
+        _userClaims[claim.to].remove(ctHash);
+    }
+
+    function _handleClaimBatch(
+        bytes32[] memory ctHashes,
+        uint64[] memory decryptedAmounts,
+        bytes[] memory decryptionProofs
+    ) internal returns (Claim[] memory claims) {
+        if (ctHashes.length != decryptedAmounts.length || ctHashes.length != decryptionProofs.length) {
+            revert LengthMismatch();
+        }
+
+        claims = new Claim[](ctHashes.length);
+        for (uint256 i = 0; i < ctHashes.length; i++) {
+            claims[i] = _handleClaim(ctHashes[i], decryptedAmounts[i], decryptionProofs[i]);
+        }
+    }
+
+    function getClaim(bytes32 ctHash) public view returns (Claim memory) {
+        return _claims[ctHash];
+    }
+
+    function getUserClaims(address user) public view returns (Claim[] memory userClaims) {
+        bytes32[] memory ctHashes = _userClaims[user].values();
+        userClaims = new Claim[](ctHashes.length);
+        for (uint256 i = 0; i < ctHashes.length; i++) {
+            userClaims[i] = _claims[ctHashes[i]];
+        }
+    }
+}

--- a/contracts/interfaces/IERC7984.sol
+++ b/contracts/interfaces/IERC7984.sol
@@ -2,9 +2,16 @@
 pragma solidity ^0.8.25;
 
 import { euint64, InEuint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-/// @dev Interface for a confidential fungible token standard utilizing the Fhenix FHE library.
-interface IERC7984 {
+/**
+ * @dev Interface for a confidential fungible token standard utilizing the Fhenix FHE library.
+ *
+ * Extends {IERC20} for backwards compatibility with wallets and block explorers. The ERC-20
+ * view functions ({balanceOf}, {totalSupply}) return **indicator values** rather than real
+ * balances, and the mutative functions ({transfer}, {transferFrom}, {approve}) revert.
+ */
+interface IERC7984 is IERC20 {
     /**
      * @dev Emitted when the expiration timestamp for an operator `operator` is updated for a given `holder`.
      * The operator may move any amount of tokens on behalf of the holder until the timestamp `until`.
@@ -39,6 +46,12 @@ interface IERC7984 {
 
     /// @dev Returns the confidential balance of the account `account`.
     function confidentialBalanceOf(address account) external view returns (euint64);
+
+    /// @dev Returns `true`, signalling that {balanceOf} returns an indicator, not a real balance.
+    function balanceOfIsIndicator() external view returns (bool);
+
+    /// @dev Returns the raw unit size of a single indicator tick (scales with {decimals}).
+    function indicatorTick() external view returns (uint256);
 
     /// @dev Returns true if `spender` is currently an operator for `holder`.
     function isOperator(address holder, address spender) external view returns (bool);

--- a/contracts/interfaces/IERC7984.sol
+++ b/contracts/interfaces/IERC7984.sol
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { euint64, InEuint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+
+/// @dev Interface for a confidential fungible token standard utilizing the Fhenix FHE library.
+interface IERC7984 {
+    /**
+     * @dev Emitted when the expiration timestamp for an operator `operator` is updated for a given `holder`.
+     * The operator may move any amount of tokens on behalf of the holder until the timestamp `until`.
+     */
+    event OperatorSet(address indexed holder, address indexed operator, uint48 until);
+
+    /// @dev Emitted when a confidential transfer is made from `from` to `to` of encrypted amount `amount`.
+    event ConfidentialTransfer(address indexed from, address indexed to, euint64 indexed amount);
+
+    /**
+     * @dev Emitted when an encrypted amount is disclosed.
+     *
+     * Accounts with access to the encrypted amount `encryptedAmount` that is also accessible to this contract
+     * should be able to disclose the amount. This functionality is implementation specific.
+     */
+    event AmountDisclosed(euint64 indexed encryptedAmount, uint64 amount);
+
+    /// @dev Returns the name of the token.
+    function name() external view returns (string memory);
+
+    /// @dev Returns the symbol of the token.
+    function symbol() external view returns (string memory);
+
+    /// @dev Returns the number of decimals of the token. Recommended to be 6.
+    function decimals() external view returns (uint8);
+
+    /// @dev Returns the contract URI. See https://eips.ethereum.org/EIPS/eip-7572[ERC-7572] for details.
+    function contractURI() external view returns (string memory);
+
+    /// @dev Returns the confidential total supply of the token.
+    function confidentialTotalSupply() external view returns (euint64);
+
+    /// @dev Returns the confidential balance of the account `account`.
+    function confidentialBalanceOf(address account) external view returns (euint64);
+
+    /// @dev Returns true if `spender` is currently an operator for `holder`.
+    function isOperator(address holder, address spender) external view returns (bool);
+
+    /**
+     * @dev Sets `operator` as an operator for `holder` until the timestamp `until`.
+     *
+     * NOTE: An operator may transfer any amount of tokens on behalf of a holder while approved.
+     */
+    function setOperator(address operator, uint48 until) external;
+
+    /**
+     * @dev Transfers the encrypted amount `encryptedAmount` to `to`.
+     *
+     * Returns the encrypted amount that was actually transferred.
+     */
+    function confidentialTransfer(address to, InEuint64 memory encryptedAmount) external returns (euint64);
+
+    /**
+     * @dev Similar to {confidentialTransfer-address-InEuint64} but without an input proof.
+     *  The caller *must* already be allowed by ACL for the given `amount`.
+     */
+    function confidentialTransfer(address to, euint64 amount) external returns (euint64 transferred);
+
+    /**
+     * @dev Transfers the encrypted amount `encryptedAmount` from `from` to `to`.
+     * `msg.sender` must be either `from` or an operator for `from`.
+     *
+     * Returns the encrypted amount that was actually transferred.
+     */
+    function confidentialTransferFrom(
+        address from,
+        address to,
+        InEuint64 memory encryptedAmount
+    ) external returns (euint64);
+
+    /**
+     * @dev Similar to {confidentialTransferFrom-address-address-InEuint64} but without an input proof.
+     * The caller *must* be already allowed by ACL for the given `amount`.
+     */
+    function confidentialTransferFrom(address from, address to, euint64 amount) external returns (euint64 transferred);
+
+    /**
+     * @dev Similar to {confidentialTransfer-address-InEuint64} but with a callback to `to` after
+     * the transfer.
+     *
+     * The callback is made to the {IERC7984Receiver-onConfidentialTransferReceived} function on the
+     * to address with the actual transferred amount (may differ from the given `encryptedAmount`) and the given
+     * data `data`.
+     */
+    function confidentialTransferAndCall(
+        address to,
+        InEuint64 memory encryptedAmount,
+        bytes calldata data
+    ) external returns (euint64 transferred);
+
+    /// @dev Similar to {confidentialTransfer-address-euint64} but with a callback to `to` after the transfer.
+    function confidentialTransferAndCall(
+        address to,
+        euint64 amount,
+        bytes calldata data
+    ) external returns (euint64 transferred);
+
+    /**
+     * @dev Similar to {confidentialTransferFrom-address-address-InEuint64} but with a callback to `to`
+     * after the transfer.
+     */
+    function confidentialTransferFromAndCall(
+        address from,
+        address to,
+        InEuint64 memory encryptedAmount,
+        bytes calldata data
+    ) external returns (euint64 transferred);
+
+    /**
+     * @dev Similar to {confidentialTransferFrom-address-address-euint64} but with a callback to `to`
+     * after the transfer.
+     *
+     */
+    function confidentialTransferFromAndCall(
+        address from,
+        address to,
+        euint64 amount,
+        bytes calldata data
+    ) external returns (euint64 transferred);
+}

--- a/contracts/interfaces/IERC7984ERC20Wrapper.sol
+++ b/contracts/interfaces/IERC7984ERC20Wrapper.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { euint64, InEuint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+
+/**
+ * @dev Interface for an {ERC7984} wrapper that shields an underlying ERC-20 token into a
+ * confidential {ERC7984} token. Users `shield` their ERC-20 tokens to receive confidential
+ * tokens, and `unshield` to burn them and reclaim the underlying.
+ *
+ * The unshield flow is asynchronous: `unshield` burns the confidential tokens and creates a
+ * decrypt request, then `claimUnshielded` verifies the decryption proof and transfers
+ * the underlying tokens.
+ */
+interface IERC7984ERC20Wrapper {
+    /// @dev Emitted when an unshield request is created.
+    event Unshielded(address indexed to, bytes32 indexed unshieldRequestId, euint64 unshieldAmount);
+
+    /// @dev Emitted when an unshield request is claimed (underlying tokens transferred).
+    event ClaimedUnshielded(
+        address indexed to,
+        bytes32 indexed unshieldRequestId,
+        euint64 indexed unshieldAmount,
+        uint64 unshieldAmountCleartext
+    );
+
+    /**
+     * @dev Shields `amount` of the underlying ERC-20 token and mints confidential tokens to `to`.
+     * The amount is rounded down to the nearest multiple of {rate} to fit confidential precision.
+     *
+     * Returns the encrypted amount of shielded tokens sent.
+     */
+    function shield(address to, uint256 amount) external returns (euint64);
+
+    /**
+     * @dev Initiates an unshield of confidential tokens from `from` and creates a pending unshield
+     * request for `to`. The caller must be `from` or an operator for `from`.
+     *
+     * Returns the unshield request ID (the cipher-text handle of the burned amount).
+     */
+    function unshield(address from, address to, euint64 amount) external returns (bytes32);
+
+    /**
+     * @dev Similar to {unshield-address-address-euint64} but accepts an encrypted input with proof.
+     */
+    function unshield(address from, address to, InEuint64 memory encryptedAmount) external returns (bytes32);
+
+    /**
+     * @dev Claims a pending unshield request by verifying the decryption proof and transferring
+     * `unshieldAmountCleartext * rate()` underlying tokens to the requester.
+     */
+    function claimUnshielded(
+        bytes32 unshieldRequestId,
+        uint64 unshieldAmountCleartext,
+        bytes calldata decryptionProof
+    ) external;
+
+    /// @dev Returns the conversion rate between the underlying ERC-20 denomination and confidential precision.
+    function rate() external view returns (uint256);
+
+    /// @dev Returns the address of the underlying ERC-20 token.
+    function underlying() external view returns (address);
+
+    /// @dev Returns the encrypted amount associated with a given unshield request ID.
+    function unshieldAmount(bytes32 unshieldRequestId) external view returns (euint64);
+
+    /// @dev Returns the recipient address for a given unshield request ID, or `address(0)` if none exists.
+    function unshieldRequester(bytes32 unshieldRequestId) external view returns (address);
+}

--- a/contracts/interfaces/IERC7984ERC20Wrapper.sol
+++ b/contracts/interfaces/IERC7984ERC20Wrapper.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { euint64, InEuint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+import { euint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
 
 /**
  * @dev Interface for an {ERC7984} wrapper that shields an underlying ERC-20 token into a
@@ -14,7 +14,7 @@ import { euint64, InEuint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
  */
 interface IERC7984ERC20Wrapper {
     /// @dev Emitted when an unshield request is created.
-    event Unshielded(address indexed to, bytes32 indexed unshieldRequestId, euint64 unshieldAmount);
+    event Unshielded(address indexed to, euint64 indexed amount);
 
     /// @dev Emitted when an unshield request is claimed (underlying tokens transferred).
     event ClaimedUnshielded(
@@ -36,14 +36,9 @@ interface IERC7984ERC20Wrapper {
      * @dev Initiates an unshield of confidential tokens from `from` and creates a pending unshield
      * request for `to`. The caller must be `from` or an operator for `from`.
      *
-     * Returns the unshield request ID (the cipher-text handle of the burned amount).
+     * Returns the encrypted amount that was burned.
      */
-    function unshield(address from, address to, euint64 amount) external returns (bytes32);
-
-    /**
-     * @dev Similar to {unshield-address-address-euint64} but accepts an encrypted input with proof.
-     */
-    function unshield(address from, address to, InEuint64 memory encryptedAmount) external returns (bytes32);
+    function unshield(address from, address to, uint64 amount) external returns (euint64);
 
     /**
      * @dev Claims a pending unshield request by verifying the decryption proof and transferring
@@ -60,10 +55,4 @@ interface IERC7984ERC20Wrapper {
 
     /// @dev Returns the address of the underlying ERC-20 token.
     function underlying() external view returns (address);
-
-    /// @dev Returns the encrypted amount associated with a given unshield request ID.
-    function unshieldAmount(bytes32 unshieldRequestId) external view returns (euint64);
-
-    /// @dev Returns the recipient address for a given unshield request ID, or `address(0)` if none exists.
-    function unshieldRequester(bytes32 unshieldRequestId) external view returns (address);
 }

--- a/contracts/interfaces/IERC7984NativeWrapper.sol
+++ b/contracts/interfaces/IERC7984NativeWrapper.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { euint64, InEuint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+import { euint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
 
 /**
  * @dev Interface for an {ERC7984} wrapper that shields a chain's native token (e.g. ETH)
@@ -20,7 +20,7 @@ interface IERC7984NativeWrapper {
     event ShieldedNative(address indexed from, address indexed to, uint256 value);
 
     /// @dev Emitted when an unshield request is created.
-    event Unshielded(address indexed to, bytes32 indexed unshieldRequestId, euint64 unshieldAmount);
+    event Unshielded(address indexed to, euint64 indexed amount);
 
     /// @dev Emitted when an unshield request is claimed (native tokens transferred).
     event ClaimedUnshielded(
@@ -51,14 +51,9 @@ interface IERC7984NativeWrapper {
      * @dev Initiates an unshield of confidential tokens from `from` and creates a pending
      * unshield request for `to`. The caller must be `from` or an operator for `from`.
      *
-     * Returns the unshield request ID (the cipher-text handle of the burned amount).
+     * Returns the encrypted amount that was burned.
      */
-    function unshield(address from, address to, euint64 amount) external returns (bytes32);
-
-    /**
-     * @dev Similar to {unshield-address-address-euint64} but accepts an encrypted input with proof.
-     */
-    function unshield(address from, address to, InEuint64 memory encryptedAmount) external returns (bytes32);
+    function unshield(address from, address to, uint64 amount) external returns (euint64);
 
     /**
      * @dev Claims a pending unshield request by verifying the decryption proof and transferring
@@ -75,10 +70,4 @@ interface IERC7984NativeWrapper {
 
     /// @dev Returns the address of the WETH contract used for wrapped-native shielding.
     function weth() external view returns (address);
-
-    /// @dev Returns the encrypted amount associated with a given unshield request ID.
-    function unshieldAmount(bytes32 unshieldRequestId) external view returns (euint64);
-
-    /// @dev Returns the recipient address for a given unshield request ID, or `address(0)` if none exists.
-    function unshieldRequester(bytes32 unshieldRequestId) external view returns (address);
 }

--- a/contracts/interfaces/IERC7984NativeWrapper.sol
+++ b/contracts/interfaces/IERC7984NativeWrapper.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { euint64, InEuint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+
+/**
+ * @dev Interface for an {ERC7984} wrapper that shields a chain's native token (e.g. ETH)
+ * into a confidential {ERC7984} token.
+ *
+ * Two shield entry-points are provided:
+ *  - {shieldWrappedNative}: pulls WETH from the caller, unwraps it, and mints confidential tokens.
+ *  - {shieldNative}: accepts native value directly and mints confidential tokens.
+ *
+ * The unshield flow is asynchronous: {unshield} burns the confidential tokens and creates a
+ * decrypt request, then {claimUnshielded} verifies the decryption proof and transfers native
+ * tokens to the recipient.
+ */
+interface IERC7984NativeWrapper {
+    /// @dev Emitted when native or wrapped-native tokens are shielded.
+    event ShieldedNative(address indexed from, address indexed to, uint256 value);
+
+    /// @dev Emitted when an unshield request is created.
+    event Unshielded(address indexed to, bytes32 indexed unshieldRequestId, euint64 unshieldAmount);
+
+    /// @dev Emitted when an unshield request is claimed (native tokens transferred).
+    event ClaimedUnshielded(
+        address indexed to,
+        bytes32 indexed unshieldRequestId,
+        euint64 indexed unshieldAmount,
+        uint64 unshieldAmountCleartext
+    );
+
+    /**
+     * @dev Shields WETH into confidential tokens. Pulls `value` WETH from the caller,
+     * unwraps it to native, and mints the equivalent confidential amount. `value` is
+     * truncated to the nearest multiple of {rate}; the remainder is not transferred.
+     *
+     * Returns the encrypted amount of shielded tokens sent.
+     */
+    function shieldWrappedNative(address to, uint256 value) external returns (euint64);
+
+    /**
+     * @dev Shields native tokens into confidential tokens. `msg.value` is truncated to
+     * the nearest multiple of {rate}; any dust below the threshold is refunded to the caller.
+     *
+     * Returns the encrypted amount of shielded tokens sent.
+     */
+    function shieldNative(address to) external payable returns (euint64);
+
+    /**
+     * @dev Initiates an unshield of confidential tokens from `from` and creates a pending
+     * unshield request for `to`. The caller must be `from` or an operator for `from`.
+     *
+     * Returns the unshield request ID (the cipher-text handle of the burned amount).
+     */
+    function unshield(address from, address to, euint64 amount) external returns (bytes32);
+
+    /**
+     * @dev Similar to {unshield-address-address-euint64} but accepts an encrypted input with proof.
+     */
+    function unshield(address from, address to, InEuint64 memory encryptedAmount) external returns (bytes32);
+
+    /**
+     * @dev Claims a pending unshield request by verifying the decryption proof and transferring
+     * `unshieldAmountCleartext * rate()` native tokens to the requester.
+     */
+    function claimUnshielded(
+        bytes32 unshieldRequestId,
+        uint64 unshieldAmountCleartext,
+        bytes calldata decryptionProof
+    ) external;
+
+    /// @dev Returns the conversion rate between the native token denomination and confidential precision.
+    function rate() external view returns (uint256);
+
+    /// @dev Returns the address of the WETH contract used for wrapped-native shielding.
+    function weth() external view returns (address);
+
+    /// @dev Returns the encrypted amount associated with a given unshield request ID.
+    function unshieldAmount(bytes32 unshieldRequestId) external view returns (euint64);
+
+    /// @dev Returns the recipient address for a given unshield request ID, or `address(0)` if none exists.
+    function unshieldRequester(bytes32 unshieldRequestId) external view returns (address);
+}

--- a/contracts/interfaces/IERC7984Receiver.sol
+++ b/contracts/interfaces/IERC7984Receiver.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {ebool, euint64} from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+
+/// @dev Interface for contracts that can receive ERC7984 transfers with a callback.
+interface IERC7984Receiver {
+    /**
+     * @dev Called upon receiving a confidential token transfer. Returns an encrypted boolean indicating success
+     * of the callback. If false is returned, the token contract will attempt to refund the transfer.
+     *
+     * WARNING: Do not manually refund the transfer AND return false, as this can lead to double refunds.
+     */
+    function onConfidentialTransferReceived(
+        address operator,
+        address from,
+        euint64 amount,
+        bytes calldata data
+    ) external returns (ebool);
+}

--- a/contracts/test/ERC7984ERC20Wrapper_Harness.sol
+++ b/contracts/test/ERC7984ERC20Wrapper_Harness.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
+import { ERC7984 } from "../ERC7984/ERC7984.sol";
+import { ERC7984ERC20Wrapper } from "../ERC7984/extensions/ERC7984ERC20Wrapper.sol";
+
+contract ERC7984ERC20Wrapper_Harness is ERC7984ERC20Wrapper {
+    constructor(
+        IERC20 underlying_,
+        string memory name_,
+        string memory symbol_,
+        string memory contractURI_
+    )
+        ERC7984("", "", 0, contractURI_)
+        ERC7984ERC20Wrapper(underlying_, name_, symbol_)
+    {}
+
+    function updateSymbol(string memory updatedSymbol) public {
+        _updateSymbol(updatedSymbol);
+    }
+}

--- a/contracts/test/ERC7984ERC20Wrapper_Harness.sol
+++ b/contracts/test/ERC7984ERC20Wrapper_Harness.sol
@@ -12,11 +12,7 @@ contract ERC7984ERC20Wrapper_Harness is ERC7984ERC20Wrapper {
         string memory symbol_,
         string memory contractURI_
     )
-        ERC7984("", "", 0, contractURI_)
-        ERC7984ERC20Wrapper(underlying_, name_, symbol_)
+        ERC7984(name_, symbol_, 0, contractURI_)
+        ERC7984ERC20Wrapper(underlying_)
     {}
-
-    function updateSymbol(string memory updatedSymbol) public {
-        _updateSymbol(updatedSymbol);
-    }
 }

--- a/contracts/test/ERC7984ERC20Wrapper_Harness.sol
+++ b/contracts/test/ERC7984ERC20Wrapper_Harness.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.25;
 
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
+import { IERC20Metadata } from "@openzeppelin/contracts/interfaces/IERC20Metadata.sol";
 import { ERC7984 } from "../ERC7984/ERC7984.sol";
 import { ERC7984ERC20Wrapper } from "../ERC7984/extensions/ERC7984ERC20Wrapper.sol";
 
@@ -12,7 +13,14 @@ contract ERC7984ERC20Wrapper_Harness is ERC7984ERC20Wrapper {
         string memory symbol_,
         string memory contractURI_
     )
-        ERC7984(name_, symbol_, 0, contractURI_)
+        ERC7984(name_, symbol_, _cappedDecimals(underlying_), contractURI_)
         ERC7984ERC20Wrapper(underlying_)
     {}
+
+    function _cappedDecimals(IERC20 token) private view returns (uint8) {
+        (bool ok, bytes memory data) = address(token).staticcall(abi.encodeCall(IERC20Metadata.decimals, ()));
+        uint8 d = (ok && data.length == 32) ? abi.decode(data, (uint8)) : 18;
+        uint8 max = _maxDecimals();
+        return d > max ? max : d;
+    }
 }

--- a/contracts/test/ERC7984NativeWrapper_Harness.sol
+++ b/contracts/test/ERC7984NativeWrapper_Harness.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
+import { IERC20Metadata } from "@openzeppelin/contracts/interfaces/IERC20Metadata.sol";
 import { IWETH } from "../interfaces/IWETH.sol";
 import { ERC7984 } from "../ERC7984/ERC7984.sol";
 import { ERC7984NativeWrapper } from "../ERC7984/extensions/ERC7984NativeWrapper.sol";
@@ -12,7 +13,13 @@ contract ERC7984NativeWrapper_Harness is ERC7984NativeWrapper {
         string memory symbol_,
         string memory contractURI_
     )
-        ERC7984(name_, symbol_, 0, contractURI_)
+        ERC7984(name_, symbol_, _cappedDecimals(weth_), contractURI_)
         ERC7984NativeWrapper(weth_)
     {}
+
+    function _cappedDecimals(IWETH token) private view returns (uint8) {
+        uint8 d = IERC20Metadata(address(token)).decimals();
+        uint8 max = _maxDecimals();
+        return d > max ? max : d;
+    }
 }

--- a/contracts/test/ERC7984NativeWrapper_Harness.sol
+++ b/contracts/test/ERC7984NativeWrapper_Harness.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { IWETH } from "../interfaces/IWETH.sol";
+import { ERC7984 } from "../ERC7984/ERC7984.sol";
+import { ERC7984NativeWrapper } from "../ERC7984/extensions/ERC7984NativeWrapper.sol";
+
+contract ERC7984NativeWrapper_Harness is ERC7984NativeWrapper {
+    constructor(
+        IWETH weth_,
+        string memory name_,
+        string memory symbol_,
+        string memory contractURI_
+    )
+        ERC7984("", "", 0, contractURI_)
+        ERC7984NativeWrapper(weth_, name_, symbol_)
+    {}
+
+    function updateSymbol(string memory updatedSymbol) public {
+        _updateSymbol(updatedSymbol);
+    }
+}

--- a/contracts/test/ERC7984NativeWrapper_Harness.sol
+++ b/contracts/test/ERC7984NativeWrapper_Harness.sol
@@ -12,11 +12,7 @@ contract ERC7984NativeWrapper_Harness is ERC7984NativeWrapper {
         string memory symbol_,
         string memory contractURI_
     )
-        ERC7984("", "", 0, contractURI_)
-        ERC7984NativeWrapper(weth_, name_, symbol_)
+        ERC7984(name_, symbol_, 0, contractURI_)
+        ERC7984NativeWrapper(weth_)
     {}
-
-    function updateSymbol(string memory updatedSymbol) public {
-        _updateSymbol(updatedSymbol);
-    }
 }

--- a/contracts/test/ERC7984_Harness.sol
+++ b/contracts/test/ERC7984_Harness.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { FHE, euint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+import { ERC7984 } from "../ERC7984/ERC7984.sol";
+
+contract ERC7984_Harness is ERC7984 {
+    constructor(
+        string memory name_,
+        string memory symbol_,
+        uint8 decimals_,
+        string memory contractURI_
+    ) ERC7984(name_, symbol_, decimals_, contractURI_) {}
+
+    function mint(address account, uint64 value) public {
+        _mint(account, FHE.asEuint64(value));
+    }
+
+    function burn(address account, uint64 value) public {
+        _burn(account, FHE.asEuint64(value));
+    }
+}

--- a/contracts/test/MockERC7984Receiver.sol
+++ b/contracts/test/MockERC7984Receiver.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { IERC7984Receiver } from "../interfaces/IERC7984Receiver.sol";
+import { ebool, euint64, FHE } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+
+contract MockERC7984Receiver is IERC7984Receiver {
+    event ConfidentialTransferCallback(bool success);
+
+    error InvalidInput(uint8 input);
+
+    function onConfidentialTransferReceived(address, address, euint64, bytes calldata data) external returns (ebool) {
+        uint8 input = abi.decode(data, (uint8));
+
+        if (input > 1) revert InvalidInput(input);
+
+        bool success = input == 1;
+        emit ConfidentialTransferCallback(success);
+
+        ebool returnVal = FHE.asEbool(success);
+        FHE.allowTransient(returnVal, msg.sender);
+
+        return returnVal;
+    }
+}

--- a/contracts/test/MockERC7984Vault.sol
+++ b/contracts/test/MockERC7984Vault.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { FHE, InEuint64, euint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+import { ERC7984 } from "../ERC7984/ERC7984.sol";
+import { FHESafeMath } from "../utils/FHESafeMath.sol";
+
+contract MockERC7984Vault {
+    ERC7984 public immutable asset;
+    mapping(address => euint64) public balances;
+
+    constructor(address _asset) {
+        require(_asset != address(0), "Invalid asset");
+        asset = ERC7984(_asset);
+    }
+
+    function deposit(InEuint64 calldata inAmount) external {
+        euint64 amount = FHE.asEuint64(inAmount);
+        FHE.allow(amount, address(asset));
+        euint64 transferred = asset.confidentialTransferFrom(msg.sender, address(this), amount);
+        (, euint64 updated) = FHESafeMath.tryAdd(balances[msg.sender], transferred);
+        balances[msg.sender] = updated;
+    }
+}

--- a/contracts/utils/FHESafeMath.sol
+++ b/contracts/utils/FHESafeMath.sol
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.25;
 
 import { FHE, ebool, euint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
 
 /**
  * @dev Library providing safe arithmetic operations for encrypted values
  * to handle potential overflows in FHE operations.
+ *
+ * NOTE: An uninitialized `euint64` value (equivalent to euint64.wrap(bytes32(0))) is evaluated as 0.
+ * This library may return an uninitialized value if all inputs are uninitialized.
  */
 library FHESafeMath {
     /**
@@ -13,15 +16,13 @@ library FHESafeMath {
      * `success` will be true and `updated` will be the new value. Otherwise, `success` will be false
      * and `updated` will be the original value.
      */
-    function tryAdd(euint64 oldValue, euint64 delta) internal returns (ebool success, euint64 updated) {
+    function tryIncrease(euint64 oldValue, euint64 delta) internal returns (ebool success, euint64 updated) {
         if (euint64.unwrap(oldValue) == 0) {
-            success = FHE.asEbool(true);
-            updated = delta;
-        } else {
-            euint64 newValue = FHE.add(oldValue, delta);
-            success = FHE.gte(newValue, oldValue);
-            updated = FHE.select(success, newValue, oldValue);
+            return (FHE.asEbool(true), delta);
         }
+        euint64 newValue = FHE.add(oldValue, delta);
+        success = FHE.gte(newValue, oldValue);
+        updated = FHE.select(success, newValue, oldValue);
     }
 
     /**
@@ -29,8 +30,45 @@ library FHESafeMath {
      * `success` will be true and `updated` will be the new value. Otherwise, `success` will be false
      * and `updated` will be the original value.
      */
-    function trySub(euint64 oldValue, euint64 delta) internal returns (ebool success, euint64 updated) {
+    function tryDecrease(euint64 oldValue, euint64 delta) internal returns (ebool success, euint64 updated) {
+        if (euint64.unwrap(delta) == 0) {
+            if (euint64.unwrap(delta) == 0) {
+                return (FHE.asEbool(true), oldValue);
+            }
+            return (FHE.eq(delta, FHE.asEuint64(0)), FHE.asEuint64(0));
+        }
         success = FHE.gte(oldValue, delta);
         updated = FHE.select(success, FHE.sub(oldValue, delta), oldValue);
+    }
+
+    /**
+     * @dev Try to add `a` and `b`. If the operation is successful, `success` will be true and `res`
+     * will be the sum of `a` and `b`. Otherwise, `success` will be false, and `res` will be 0.
+     */
+    function tryAdd(euint64 a, euint64 b) internal returns (ebool success, euint64 res) {
+        if (euint64.unwrap(a) == 0) {
+            return (FHE.asEbool(true), b);
+        }
+        if (euint64.unwrap(b) == 0) {
+            return (FHE.asEbool(true), a);
+        }
+
+        euint64 sum = FHE.add(a, b);
+        success = FHE.gte(sum, a);
+        res = FHE.select(success, sum, FHE.asEuint64(0));
+    }
+
+    /**
+     * @dev Try to subtract `b` from `a`. If the operation is successful, `success` will be true and `res`
+     * will be `a - b`. Otherwise, `success` will be false, and `res` will be 0.
+     */
+    function trySub(euint64 a, euint64 b) internal returns (ebool success, euint64 res) {
+        if (euint64.unwrap(b) == 0) {
+            return (FHE.asEbool(true), a);
+        }
+
+        euint64 difference = FHE.sub(a, b);
+        success = FHE.lte(difference, a);
+        res = FHE.select(success, difference, FHE.asEuint64(0));
     }
 }

--- a/contracts/utils/FHESafeMath.sol
+++ b/contracts/utils/FHESafeMath.sol
@@ -7,7 +7,7 @@ import { FHE, ebool, euint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
  * @dev Library providing safe arithmetic operations for encrypted values
  * to handle potential overflows in FHE operations.
  *
- * NOTE: An uninitialized `euint64` value (equivalent to euint64.wrap(bytes32(0))) is evaluated as 0.
+ * NOTE: An uninitialized `euint64` value is evaluated as 0.
  * This library may return an uninitialized value if all inputs are uninitialized.
  */
 library FHESafeMath {
@@ -17,7 +17,7 @@ library FHESafeMath {
      * and `updated` will be the original value.
      */
     function tryIncrease(euint64 oldValue, euint64 delta) internal returns (ebool success, euint64 updated) {
-        if (euint64.unwrap(oldValue) == 0) {
+        if (!FHE.isInitialized(oldValue)) {
             return (FHE.asEbool(true), delta);
         }
         euint64 newValue = FHE.add(oldValue, delta);
@@ -31,8 +31,8 @@ library FHESafeMath {
      * and `updated` will be the original value.
      */
     function tryDecrease(euint64 oldValue, euint64 delta) internal returns (ebool success, euint64 updated) {
-        if (euint64.unwrap(oldValue) == 0) {
-            if (euint64.unwrap(delta) == 0) {
+        if (!FHE.isInitialized(oldValue)) {
+            if (!FHE.isInitialized(delta)) {
                 return (FHE.asEbool(true), oldValue);
             }
             return (FHE.eq(delta, FHE.asEuint64(0)), FHE.asEuint64(0));
@@ -46,10 +46,10 @@ library FHESafeMath {
      * will be the sum of `a` and `b`. Otherwise, `success` will be false, and `res` will be 0.
      */
     function tryAdd(euint64 a, euint64 b) internal returns (ebool success, euint64 res) {
-        if (euint64.unwrap(a) == 0) {
+        if (!FHE.isInitialized(a)) {
             return (FHE.asEbool(true), b);
         }
-        if (euint64.unwrap(b) == 0) {
+        if (!FHE.isInitialized(b)) {
             return (FHE.asEbool(true), a);
         }
 
@@ -63,7 +63,7 @@ library FHESafeMath {
      * will be `a - b`. Otherwise, `success` will be false, and `res` will be 0.
      */
     function trySub(euint64 a, euint64 b) internal returns (ebool success, euint64 res) {
-        if (euint64.unwrap(b) == 0) {
+        if (!FHE.isInitialized(b)) {
             return (FHE.asEbool(true), a);
         }
 

--- a/contracts/utils/FHESafeMath.sol
+++ b/contracts/utils/FHESafeMath.sol
@@ -31,7 +31,7 @@ library FHESafeMath {
      * and `updated` will be the original value.
      */
     function tryDecrease(euint64 oldValue, euint64 delta) internal returns (ebool success, euint64 updated) {
-        if (euint64.unwrap(delta) == 0) {
+        if (euint64.unwrap(oldValue) == 0) {
             if (euint64.unwrap(delta) == 0) {
                 return (FHE.asEbool(true), oldValue);
             }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@cofhe/sdk": "0.3.2",
     "@ethersproject/abi": "~5.7.0",
     "@ethersproject/providers": "~5.7.2",
-    "@fhenixprotocol/cofhe-contracts": "0.1.0",
+    "@fhenixprotocol/cofhe-contracts": "0.1.3",
     "@fhenixprotocol/cofhe-mock-contracts": "^0.3.1",
     "@nomicfoundation/hardhat-chai-matchers": "~2.0.7",
     "@nomicfoundation/hardhat-ethers": "~3.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 2.30.0(@types/node@24.1.0)
       '@cofhe/hardhat-plugin':
         specifier: 0.3.2
-        version: 0.3.2(@fhenixprotocol/cofhe-contracts@0.1.0)(@nomicfoundation/hardhat-ethers@3.0.9(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4)))(@openzeppelin/contracts@5.4.0)(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4))(typescript@5.5.4)(zod@3.25.76)
+        version: 0.3.2(@fhenixprotocol/cofhe-contracts@0.1.3)(@nomicfoundation/hardhat-ethers@3.0.9(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4)))(@openzeppelin/contracts@5.4.0)(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4))(typescript@5.5.4)(zod@3.25.76)
       '@cofhe/mock-contracts':
         specifier: 0.3.2
         version: 0.3.2
@@ -43,11 +43,11 @@ importers:
         specifier: ~5.7.2
         version: 5.7.2
       '@fhenixprotocol/cofhe-contracts':
-        specifier: 0.1.0
-        version: 0.1.0
+        specifier: 0.1.3
+        version: 0.1.3
       '@fhenixprotocol/cofhe-mock-contracts':
         specifier: ^0.3.1
-        version: 0.3.1(@fhenixprotocol/cofhe-contracts@0.1.0)(@openzeppelin/contracts-upgradeable@5.4.0(@openzeppelin/contracts@5.4.0))(@openzeppelin/contracts@5.4.0)
+        version: 0.3.1(@fhenixprotocol/cofhe-contracts@0.1.3)(@openzeppelin/contracts-upgradeable@5.4.0(@openzeppelin/contracts@5.4.0))(@openzeppelin/contracts@5.4.0)
       '@nomicfoundation/hardhat-chai-matchers':
         specifier: ~2.0.7
         version: 2.0.9(@nomicfoundation/hardhat-ethers@3.0.9(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4)))(chai@4.5.0)(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4))
@@ -391,6 +391,9 @@ packages:
 
   '@fhenixprotocol/cofhe-contracts@0.1.0':
     resolution: {integrity: sha512-Nt5+bJtRgiT9lUrBXEEhJLttVtqO/Rk7wI5KC5+la1zGcYnCym/mT+ExlyjsX+Pf9cpE2Qje8nhfTDSMERGLtA==}
+
+  '@fhenixprotocol/cofhe-contracts@0.1.3':
+    resolution: {integrity: sha512-VegEHsy3a6DMHGlzhw5Xbqhp7zYvlK601z5VO5qQeeBjmOXEVhyWvVrpvmJgZfpDoT+bdCL19qExBJzKH5aYvA==}
 
   '@fhenixprotocol/cofhe-mock-contracts@0.3.1':
     resolution: {integrity: sha512-a2Fi9e6emgoPwO/vMhN9m/QXHl7ypQP1YixlJaLkAX80vtm2rAM77O7xcslCzH7R9NNHGJxiME+comrpNjII5g==}
@@ -3168,11 +3171,11 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@cofhe/hardhat-plugin@0.3.2(@fhenixprotocol/cofhe-contracts@0.1.0)(@nomicfoundation/hardhat-ethers@3.0.9(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4)))(@openzeppelin/contracts@5.4.0)(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4))(typescript@5.5.4)(zod@3.25.76)':
+  '@cofhe/hardhat-plugin@0.3.2(@fhenixprotocol/cofhe-contracts@0.1.3)(@nomicfoundation/hardhat-ethers@3.0.9(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4)))(@openzeppelin/contracts@5.4.0)(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4))(typescript@5.5.4)(zod@3.25.76)':
     dependencies:
       '@cofhe/mock-contracts': 0.3.2
       '@cofhe/sdk': 0.3.2(@nomicfoundation/hardhat-ethers@3.0.9(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4)))(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4))(viem@2.47.1(typescript@5.5.4)(zod@3.25.76))
-      '@fhenixprotocol/cofhe-contracts': 0.1.0
+      '@fhenixprotocol/cofhe-contracts': 0.1.3
       '@nomicfoundation/hardhat-ethers': 3.0.9(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4))
       '@openzeppelin/contracts': 5.4.0
       chai: 4.5.0
@@ -3568,9 +3571,13 @@ snapshots:
     dependencies:
       '@openzeppelin/contracts': 5.4.0
 
-  '@fhenixprotocol/cofhe-mock-contracts@0.3.1(@fhenixprotocol/cofhe-contracts@0.1.0)(@openzeppelin/contracts-upgradeable@5.4.0(@openzeppelin/contracts@5.4.0))(@openzeppelin/contracts@5.4.0)':
+  '@fhenixprotocol/cofhe-contracts@0.1.3':
     dependencies:
-      '@fhenixprotocol/cofhe-contracts': 0.1.0
+      '@openzeppelin/contracts': 5.4.0
+
+  '@fhenixprotocol/cofhe-mock-contracts@0.3.1(@fhenixprotocol/cofhe-contracts@0.1.3)(@openzeppelin/contracts-upgradeable@5.4.0(@openzeppelin/contracts@5.4.0))(@openzeppelin/contracts@5.4.0)':
+    dependencies:
+      '@fhenixprotocol/cofhe-contracts': 0.1.3
       '@openzeppelin/contracts': 5.4.0
       '@openzeppelin/contracts-upgradeable': 5.4.0(@openzeppelin/contracts@5.4.0)
 

--- a/test/ERC7984.test.ts
+++ b/test/ERC7984.test.ts
@@ -641,6 +641,220 @@ describe("ERC7984", function () {
       );
     });
   });
+
+  describe("ERC-20 indicator", function () {
+    // Token has 6 decimals → tick = 10^(6-4) = 100
+    const tick = 100n;
+    const base = 79_840_000n * tick; // 7984.000000
+    const transferVal = 79_840_001n * tick; // 7984.000100
+
+    it("should return 0 for accounts that have never interacted", async function () {
+      const { token, bob } = await setupFixture();
+
+      expect(await token.balanceOf(bob.address)).to.equal(0n);
+    });
+
+    it("should return base + 1 tick after first receive (mint)", async function () {
+      const { token, bob } = await setupFixture();
+
+      await token.mint(bob.address, 1_000_000n);
+
+      expect(await token.balanceOf(bob.address)).to.equal(base + tick);
+    });
+
+    it("should increment on receive and decrement on send", async function () {
+      const { token, bob, alice, bobClient } = await setupFixture();
+
+      await token.mint(bob.address, 5_000_000n);
+      expect(await token.balanceOf(bob.address)).to.equal(base + tick);
+
+      // Transfer bob → alice: bob decrements, alice initialises
+      const [enc] = await bobClient.encryptInputs([Encryptable.uint64(1_000_000n)]).execute();
+      await token.connect(bob)["confidentialTransfer(address,(uint256,uint8,uint8,bytes))"](alice.address, enc);
+
+      expect(await token.balanceOf(bob.address)).to.equal(base); // 7984.0000
+      expect(await token.balanceOf(alice.address)).to.equal(base + tick); // 7984.0001
+    });
+
+    it("should go below base (7983.9999) after more sends than receives", async function () {
+      const { token, bob, alice, bobClient } = await setupFixture();
+
+      // 1 receive (mint)
+      await token.mint(bob.address, 5_000_000n);
+      expect(await token.balanceOf(bob.address)).to.equal(base + tick); // 7984.0001
+
+      // 4 sends → net = 1 receive - 4 sends = indicator at base - 3
+      for (let i = 0; i < 4; i++) {
+        const [enc] = await bobClient.encryptInputs([Encryptable.uint64(100_000n)]).execute();
+        await token.connect(bob)["confidentialTransfer(address,(uint256,uint8,uint8,bytes))"](alice.address, enc);
+      }
+
+      // 79840001 - 4 = 79839997 → 7983.9997 in display
+      expect(await token.balanceOf(bob.address)).to.equal(79_839_997n * tick);
+    });
+
+    it("should emit Transfer event with 7984.0001 value", async function () {
+      const { token, bob } = await setupFixture();
+
+      await expect(token.mint(bob.address, 1_000_000n))
+        .to.emit(token, "Transfer")
+        .withArgs(ZeroAddress, bob.address, transferVal);
+    });
+
+    it("should track totalSupply indicator on mint and burn", async function () {
+      const { token, bob } = await setupFixture();
+
+      expect(await token.totalSupply()).to.equal(0n);
+
+      await token.mint(bob.address, 1_000_000n);
+      expect(await token.totalSupply()).to.equal(base + tick);
+
+      await token.mint(bob.address, 1_000_000n);
+      expect(await token.totalSupply()).to.equal(base + 2n * tick);
+
+      await token.burn(bob.address, 500_000n);
+      expect(await token.totalSupply()).to.equal(base + tick);
+    });
+
+    it("should report balanceOfIsIndicator as true", async function () {
+      const { token } = await setupFixture();
+      expect(await token.balanceOfIsIndicator()).to.equal(true);
+    });
+
+    it("should report correct indicatorTick for 6 decimals", async function () {
+      const { token } = await setupFixture();
+      expect(await token.indicatorTick()).to.equal(tick);
+    });
+
+    it("should reset indicated balance to 0", async function () {
+      const { token, bob } = await setupFixture();
+
+      await token.mint(bob.address, 1_000_000n);
+      expect(await token.balanceOf(bob.address)).to.not.equal(0n);
+
+      await token.connect(bob).resetIndicatedBalance();
+      expect(await token.balanceOf(bob.address)).to.equal(0n);
+    });
+
+    it("should revert on ERC-20 transfer", async function () {
+      const { token, bob, alice } = await setupFixture();
+      await expect(token.connect(bob).transfer(alice.address, 1n)).to.be.revertedWithCustomError(
+        token,
+        "ERC7984IncompatibleFunction",
+      );
+    });
+
+    it("should revert on ERC-20 transferFrom", async function () {
+      const { token, bob, alice } = await setupFixture();
+      await expect(token.connect(bob).transferFrom(bob.address, alice.address, 1n)).to.be.revertedWithCustomError(
+        token,
+        "ERC7984IncompatibleFunction",
+      );
+    });
+
+    it("should revert on ERC-20 approve", async function () {
+      const { token, bob, alice } = await setupFixture();
+      await expect(token.connect(bob).approve(alice.address, 1n)).to.be.revertedWithCustomError(
+        token,
+        "ERC7984IncompatibleFunction",
+      );
+    });
+
+    it("should revert on ERC-20 allowance", async function () {
+      const { token, bob, alice } = await setupFixture();
+      await expect(token.allowance(bob.address, alice.address)).to.be.revertedWithCustomError(
+        token,
+        "ERC7984IncompatibleFunction",
+      );
+    });
+
+    it("should support IERC20 interface", async function () {
+      const { token } = await setupFixture();
+      // IERC20 interfaceId = 0x36372b07
+      expect(await token.supportsInterface("0x36372b07")).to.equal(true);
+    });
+  });
+
+  describe("ERC-20 indicator across decimal values", function () {
+    async function deployWithDecimals(decimals: number) {
+      const factory = await ethers.getContractFactory("ERC7984_Harness");
+      const token = (await factory.deploy("Test", "T", decimals, "")) as ERC7984_Harness;
+      await token.waitForDeployment();
+      return token;
+    }
+
+    it("should work with 18 decimals (tick = 1e14)", async function () {
+      const [, bob, alice] = await ethers.getSigners();
+      const bobClient = await hre.cofhe.createClientWithBatteries(bob);
+      const token = await deployWithDecimals(18);
+
+      const tick = 10n ** 14n; // 10^(18-4)
+      const base = 79_840_000n * tick;
+
+      expect(await token.indicatorTick()).to.equal(tick);
+      expect(await token.balanceOf(bob.address)).to.equal(0n);
+
+      await token.mint(bob.address, 1_000_000n);
+      expect(await token.balanceOf(bob.address)).to.equal(base + tick);
+
+      const [enc] = await bobClient.encryptInputs([Encryptable.uint64(100_000n)]).execute();
+      await token.connect(bob)["confidentialTransfer(address,(uint256,uint8,uint8,bytes))"](alice.address, enc);
+
+      expect(await token.balanceOf(bob.address)).to.equal(base); // 7984.000000000000000000
+      expect(await token.balanceOf(alice.address)).to.equal(base + tick); // 7984.000100000000000000
+    });
+
+    it("should work with 6 decimals (tick = 100)", async function () {
+      const [, bob] = await ethers.getSigners();
+      const token = await deployWithDecimals(6);
+
+      const tick = 100n; // 10^(6-4)
+      const base = 79_840_000n * tick;
+
+      expect(await token.indicatorTick()).to.equal(tick);
+
+      await token.mint(bob.address, 500_000n);
+      expect(await token.balanceOf(bob.address)).to.equal(base + tick);
+    });
+
+    it("should work with 4 decimals (tick = 1)", async function () {
+      const [, bob] = await ethers.getSigners();
+      const token = await deployWithDecimals(4);
+
+      const tick = 1n; // decimals <= 4 → tick = 1
+      const base = 79_840_000n * tick;
+
+      expect(await token.indicatorTick()).to.equal(tick);
+
+      await token.mint(bob.address, 500n);
+      expect(await token.balanceOf(bob.address)).to.equal(base + tick); // 7984.0001
+    });
+
+    it("should work with 2 decimals (tick = 1)", async function () {
+      const [, bob] = await ethers.getSigners();
+      const token = await deployWithDecimals(2);
+
+      const tick = 1n; // decimals <= 4 → tick = 1
+      const base = 79_840_000n * tick;
+
+      expect(await token.indicatorTick()).to.equal(tick);
+
+      await token.mint(bob.address, 50n);
+      // Displays as 798400.01 with 2 decimals — the "7984" prefix is in the integer part
+      expect(await token.balanceOf(bob.address)).to.equal(base + tick);
+    });
+
+    it("should work with 0 decimals (tick = 1)", async function () {
+      const [, bob] = await ethers.getSigners();
+      const token = await deployWithDecimals(0);
+
+      expect(await token.indicatorTick()).to.equal(1n);
+
+      await token.mint(bob.address, 1n);
+      // Raw integer 79840001 — no decimal point
+      expect(await token.balanceOf(bob.address)).to.equal(79_840_001n);
+    });
+  });
 });
 
 async function getIERC7984InterfaceId(): Promise<string> {
@@ -651,6 +865,8 @@ async function getIERC7984InterfaceId(): Promise<string> {
     "contractURI()",
     "confidentialTotalSupply()",
     "confidentialBalanceOf(address)",
+    "balanceOfIsIndicator()",
+    "indicatorTick()",
     "isOperator(address,address)",
     "setOperator(address,uint48)",
     "confidentialTransfer(address,(uint256,uint8,uint8,bytes))",

--- a/test/ERC7984.test.ts
+++ b/test/ERC7984.test.ts
@@ -1,0 +1,674 @@
+import { expect } from "chai";
+import hre, { ethers } from "hardhat";
+import { ERC7984_Harness } from "../typechain-types";
+import { Encryptable } from "@cofhe/sdk";
+import { prepExpectERC7984BalancesChange, expectERC7984BalancesChange } from "./utils";
+import { ZeroAddress } from "ethers";
+
+describe("ERC7984", function () {
+  const deployContracts = async () => {
+    const factory = await ethers.getContractFactory("ERC7984_Harness");
+    const token = (await factory.deploy(
+      "Test Token",
+      "TST",
+      6,
+      "https://example.com/contract.json",
+    )) as ERC7984_Harness;
+    await token.waitForDeployment();
+    return { token };
+  };
+
+  async function setupFixture() {
+    const [owner, bob, alice, eve] = await ethers.getSigners();
+    const { token } = await deployContracts();
+
+    const ownerClient = await hre.cofhe.createClientWithBatteries(owner);
+    const bobClient = await hre.cofhe.createClientWithBatteries(bob);
+    const aliceClient = await hre.cofhe.createClientWithBatteries(alice);
+    const eveClient = await hre.cofhe.createClientWithBatteries(eve);
+
+    return { ownerClient, bobClient, aliceClient, eveClient, owner, bob, alice, eve, token };
+  }
+
+  describe("initialization", function () {
+    it("should be constructed correctly", async function () {
+      const { token } = await setupFixture();
+
+      expect(await token.name()).to.equal("Test Token");
+      expect(await token.symbol()).to.equal("TST");
+      expect(await token.decimals()).to.equal(6);
+      expect(await token.contractURI()).to.equal("https://example.com/contract.json");
+      expect(await token.confidentialTotalSupply()).to.equal(0n);
+    });
+
+    it("should support IERC7984 and ERC165 interfaces", async function () {
+      const { token } = await setupFixture();
+
+      // IERC165 interfaceId = 0x01ffc9a7
+      expect(await token.supportsInterface("0x01ffc9a7")).to.equal(true);
+
+      // IERC7984 interfaceId
+      expect(await token.supportsInterface(await getIERC7984InterfaceId())).to.equal(true);
+
+      // Random unsupported interfaceId
+      expect(await token.supportsInterface("0xdeadbeef")).to.equal(false);
+    });
+  });
+
+  describe("mint", function () {
+    it("should mint tokens", async function () {
+      const { bob, token } = await setupFixture();
+
+      expect(await token.confidentialTotalSupply()).to.equal(0n);
+
+      const value = 1_000_000n; // 1 token with 6 decimals
+
+      await prepExpectERC7984BalancesChange(token, bob.address);
+
+      await token.mint(bob.address, value);
+
+      await expectERC7984BalancesChange(token, bob.address, value);
+      await hre.cofhe.mocks.expectPlaintext(await token.confidentialTotalSupply(), value);
+
+      // Mint again and verify cumulative balance
+      await prepExpectERC7984BalancesChange(token, bob.address);
+
+      await token.mint(bob.address, value);
+
+      await expectERC7984BalancesChange(token, bob.address, value);
+      await hre.cofhe.mocks.expectPlaintext(await token.confidentialTotalSupply(), value * 2n);
+    });
+
+    it("should revert if minting to the zero address", async function () {
+      const { token } = await setupFixture();
+
+      await expect(token.mint(ZeroAddress, 1_000_000n)).to.be.revertedWithCustomError(token, "ERC7984InvalidReceiver");
+    });
+
+    it("should emit ConfidentialTransfer event on mint", async function () {
+      const { bob, token } = await setupFixture();
+
+      await expect(token.mint(bob.address, 1_000_000n)).to.emit(token, "ConfidentialTransfer");
+    });
+  });
+
+  describe("burn", function () {
+    it("should burn tokens", async function () {
+      const { token, bob } = await setupFixture();
+
+      const mintValue = 10_000_000n;
+      const burnValue = 1_000_000n;
+
+      await token.mint(bob.address, mintValue);
+
+      await prepExpectERC7984BalancesChange(token, bob.address);
+
+      await token.burn(bob.address, burnValue);
+
+      await expectERC7984BalancesChange(token, bob.address, -1n * burnValue);
+      await hre.cofhe.mocks.expectPlaintext(await token.confidentialTotalSupply(), mintValue - burnValue);
+    });
+
+    it("should revert if burning from the zero address", async function () {
+      const { token } = await setupFixture();
+
+      await expect(token.burn(ZeroAddress, 1_000_000n)).to.be.revertedWithCustomError(token, "ERC7984InvalidSender");
+    });
+
+    it("should emit ConfidentialTransfer event on burn", async function () {
+      const { bob, token } = await setupFixture();
+
+      await token.mint(bob.address, 10_000_000n);
+
+      await expect(token.burn(bob.address, 1_000_000n)).to.emit(token, "ConfidentialTransfer");
+    });
+  });
+
+  describe("confidentialTransfer", function () {
+    it("should transfer from bob to alice (InEuint64)", async function () {
+      const { token, bob, alice, bobClient } = await setupFixture();
+
+      const mintValue = 10_000_000n;
+      await token.mint(bob.address, mintValue);
+      await token.mint(alice.address, mintValue);
+
+      const transferValue = 1_000_000n;
+      const [encTransferInput] = await bobClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+
+      await prepExpectERC7984BalancesChange(token, bob.address);
+      await prepExpectERC7984BalancesChange(token, alice.address);
+
+      await expect(
+        token
+          .connect(bob)
+          ["confidentialTransfer(address,(uint256,uint8,uint8,bytes))"](alice.address, encTransferInput),
+      ).to.emit(token, "ConfidentialTransfer");
+
+      await expectERC7984BalancesChange(token, bob.address, -1n * transferValue);
+      await expectERC7984BalancesChange(token, alice.address, transferValue);
+    });
+
+    it("should revert on transfer to zero address", async function () {
+      const { token, bob, bobClient } = await setupFixture();
+
+      await token.mint(bob.address, 10_000_000n);
+
+      const transferValue = 1_000_000n;
+      const [encTransferInput] = await bobClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+
+      await expect(
+        token.connect(bob)["confidentialTransfer(address,(uint256,uint8,uint8,bytes))"](ZeroAddress, encTransferInput),
+      ).to.be.revertedWithCustomError(token, "ERC7984InvalidReceiver");
+    });
+
+    it("should handle transfer exceeding balance (transfers 0 instead)", async function () {
+      const { token, bob, alice, bobClient } = await setupFixture();
+
+      const mintValue = 1_000_000n;
+      await token.mint(bob.address, mintValue);
+      await token.mint(alice.address, mintValue);
+
+      // Try to transfer more than balance
+      const transferValue = 10_000_000n;
+      const [encTransferInput] = await bobClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+
+      await prepExpectERC7984BalancesChange(token, bob.address);
+      await prepExpectERC7984BalancesChange(token, alice.address);
+
+      await token
+        .connect(bob)
+        ["confidentialTransfer(address,(uint256,uint8,uint8,bytes))"](alice.address, encTransferInput);
+
+      // FHESafeMath.tryDecrease fails, so transferred amount becomes 0
+      await expectERC7984BalancesChange(token, bob.address, 0n);
+      await expectERC7984BalancesChange(token, alice.address, 0n);
+    });
+  });
+
+  describe("operator management", function () {
+    it("should return true when operator is set", async function () {
+      const { token, bob, alice } = await setupFixture();
+
+      const timestamp = (await ethers.provider.getBlock("latest"))!.timestamp + 100;
+      await token.connect(bob).setOperator(alice.address, timestamp);
+
+      expect(await token.isOperator(bob.address, alice.address)).to.equal(true);
+    });
+
+    it("should return false when operator is not set", async function () {
+      const { token, bob, alice } = await setupFixture();
+
+      expect(await token.isOperator(bob.address, alice.address)).to.equal(false);
+    });
+
+    it("should return false when operator has expired", async function () {
+      const { token, bob, alice } = await setupFixture();
+
+      const timestamp = (await ethers.provider.getBlock("latest"))!.timestamp - 100;
+      await token.connect(bob).setOperator(alice.address, timestamp);
+
+      expect(await token.isOperator(bob.address, alice.address)).to.equal(false);
+    });
+
+    it("should remove operator when setting timestamp to 0", async function () {
+      const { token, bob, alice } = await setupFixture();
+
+      const timestamp = (await ethers.provider.getBlock("latest"))!.timestamp + 100;
+      await token.connect(bob).setOperator(alice.address, timestamp);
+      expect(await token.isOperator(bob.address, alice.address)).to.equal(true);
+
+      await token.connect(bob).setOperator(alice.address, 0);
+      expect(await token.isOperator(bob.address, alice.address)).to.equal(false);
+    });
+
+    it("should return true when holder is their own operator", async function () {
+      const { token, bob } = await setupFixture();
+
+      expect(await token.isOperator(bob.address, bob.address)).to.equal(true);
+    });
+
+    it("should emit OperatorSet event", async function () {
+      const { token, bob, alice } = await setupFixture();
+
+      const timestamp = (await ethers.provider.getBlock("latest"))!.timestamp + 100;
+      await expect(token.connect(bob).setOperator(alice.address, timestamp))
+        .to.emit(token, "OperatorSet")
+        .withArgs(bob.address, alice.address, timestamp);
+    });
+  });
+
+  describe("confidentialTransferFrom", function () {
+    const setupTransferFromFixture = async () => {
+      const { token, bob, alice, eve, aliceClient, eveClient, bobClient } = await setupFixture();
+
+      const mintValue = 10_000_000n;
+      await token.mint(bob.address, mintValue);
+      await token.mint(alice.address, mintValue);
+
+      return { token, bob, alice, eve, aliceClient, eveClient, bobClient };
+    };
+
+    it("should transfer from bob to alice (alice as operator)", async function () {
+      const { token, bob, alice, aliceClient } = await setupTransferFromFixture();
+
+      const timestamp = (await ethers.provider.getBlock("latest"))!.timestamp + 100;
+      await token.connect(bob).setOperator(alice.address, timestamp);
+
+      const transferValue = 1_000_000n;
+      const [encTransferInput] = await aliceClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+
+      await prepExpectERC7984BalancesChange(token, bob.address);
+      await prepExpectERC7984BalancesChange(token, alice.address);
+
+      await expect(
+        token
+          .connect(alice)
+          [
+            "confidentialTransferFrom(address,address,(uint256,uint8,uint8,bytes))"
+          ](bob.address, alice.address, encTransferInput),
+      ).to.emit(token, "ConfidentialTransfer");
+
+      await expectERC7984BalancesChange(token, bob.address, -1n * transferValue);
+      await expectERC7984BalancesChange(token, alice.address, transferValue);
+    });
+
+    it("should transfer from bob to alice (eve as operator)", async function () {
+      const { token, bob, alice, eve, eveClient } = await setupTransferFromFixture();
+
+      const timestamp = (await ethers.provider.getBlock("latest"))!.timestamp + 100;
+      await token.connect(bob).setOperator(eve.address, timestamp);
+
+      const transferValue = 1_000_000n;
+      const [encTransferInput] = await eveClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+
+      await prepExpectERC7984BalancesChange(token, bob.address);
+      await prepExpectERC7984BalancesChange(token, alice.address);
+
+      await expect(
+        token
+          .connect(eve)
+          [
+            "confidentialTransferFrom(address,address,(uint256,uint8,uint8,bytes))"
+          ](bob.address, alice.address, encTransferInput),
+      ).to.emit(token, "ConfidentialTransfer");
+
+      await expectERC7984BalancesChange(token, bob.address, -1n * transferValue);
+      await expectERC7984BalancesChange(token, alice.address, transferValue);
+    });
+
+    it("should transfer from bob to MockERC7984Vault", async function () {
+      const { token, bob, bobClient } = await setupTransferFromFixture();
+
+      const vaultFactory = await ethers.getContractFactory("MockERC7984Vault");
+      const vault = await vaultFactory.deploy(token.target);
+      await vault.waitForDeployment();
+      const vaultAddress = await vault.getAddress();
+
+      // Mint to vault so it has an initialized balance
+      await token.mint(vaultAddress, 1_000_000n);
+
+      const timestamp = (await ethers.provider.getBlock("latest"))!.timestamp + 100;
+      await token.connect(bob).setOperator(vaultAddress, timestamp);
+
+      const transferValue = 1_000_000n;
+      const [encTransferInput] = await bobClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+
+      await prepExpectERC7984BalancesChange(token, bob.address);
+      await prepExpectERC7984BalancesChange(token, vaultAddress);
+
+      await expect(vault.connect(bob).deposit(encTransferInput)).to.emit(token, "ConfidentialTransfer");
+
+      await expectERC7984BalancesChange(token, bob.address, -1n * transferValue);
+      await expectERC7984BalancesChange(token, vaultAddress, transferValue);
+    });
+
+    it("should revert if invalid receiver (zero address)", async function () {
+      const { token, bob, alice, aliceClient } = await setupTransferFromFixture();
+
+      const timestamp = (await ethers.provider.getBlock("latest"))!.timestamp + 100;
+      await token.connect(bob).setOperator(alice.address, timestamp);
+
+      const transferValue = 1_000_000n;
+      const [encTransferInput] = await aliceClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+
+      await expect(
+        token
+          .connect(alice)
+          [
+            "confidentialTransferFrom(address,address,(uint256,uint8,uint8,bytes))"
+          ](bob.address, ZeroAddress, encTransferInput),
+      ).to.be.revertedWithCustomError(token, "ERC7984InvalidReceiver");
+    });
+
+    it("should revert on spender mismatch (not an operator)", async function () {
+      const { token, bob, alice, eve, aliceClient } = await setupTransferFromFixture();
+
+      // Set eve as operator for bob (not alice)
+      const timestamp = (await ethers.provider.getBlock("latest"))!.timestamp + 100;
+      await token.connect(bob).setOperator(eve.address, timestamp);
+
+      const transferValue = 1_000_000n;
+      const [encTransferInput] = await aliceClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+
+      await expect(
+        token
+          .connect(alice)
+          [
+            "confidentialTransferFrom(address,address,(uint256,uint8,uint8,bytes))"
+          ](bob.address, alice.address, encTransferInput),
+      ).to.be.revertedWithCustomError(token, "ERC7984UnauthorizedSpender");
+    });
+  });
+
+  describe("confidentialTransferAndCall", function () {
+    const setupTransferAndCallFixture = async () => {
+      const { token, bob, alice, eve, bobClient } = await setupFixture();
+
+      const mintValue = 10_000_000n;
+      await token.mint(bob.address, mintValue);
+
+      const receiverFactory = await ethers.getContractFactory("MockERC7984Receiver");
+      const receiver = await receiverFactory.deploy();
+      await receiver.waitForDeployment();
+
+      const transferValue = 1_000_000n;
+      const [encTransferInput] = await bobClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+
+      return { token, bob, alice, eve, receiver, encTransferInput, transferValue };
+    };
+
+    it("should transfer with callback to receiver (success)", async function () {
+      const { token, bob, receiver, encTransferInput, transferValue } = await setupTransferAndCallFixture();
+
+      const receiverAddress = await receiver.getAddress();
+
+      await prepExpectERC7984BalancesChange(token, bob.address);
+      await prepExpectERC7984BalancesChange(token, receiverAddress);
+
+      const callData = ethers.AbiCoder.defaultAbiCoder().encode(["uint8"], [1]);
+
+      const tx = await token
+        .connect(bob)
+        [
+          "confidentialTransferAndCall(address,(uint256,uint8,uint8,bytes),bytes)"
+        ](receiverAddress, encTransferInput, callData);
+
+      await expect(tx).to.emit(receiver, "ConfidentialTransferCallback").withArgs(true);
+
+      // Successful callback: transfer goes through, refund is 0
+      await expectERC7984BalancesChange(token, bob.address, -1n * transferValue);
+      await expectERC7984BalancesChange(token, receiverAddress, transferValue);
+    });
+
+    it("should transfer with callback to receiver (failure - refund)", async function () {
+      const { token, bob, receiver, encTransferInput } = await setupTransferAndCallFixture();
+
+      const receiverAddress = await receiver.getAddress();
+
+      await prepExpectERC7984BalancesChange(token, bob.address);
+      await prepExpectERC7984BalancesChange(token, receiverAddress);
+
+      const callData = ethers.AbiCoder.defaultAbiCoder().encode(["uint8"], [0]);
+
+      await expect(
+        token
+          .connect(bob)
+          [
+            "confidentialTransferAndCall(address,(uint256,uint8,uint8,bytes),bytes)"
+          ](receiverAddress, encTransferInput, callData),
+      ).to.emit(receiver, "ConfidentialTransferCallback");
+
+      // Failed callback: transfer should be refunded, balances unchanged
+      await expectERC7984BalancesChange(token, bob.address, 0n);
+      await expectERC7984BalancesChange(token, receiverAddress, 0n);
+    });
+
+    it("should transfer with callback to EOA (always succeeds)", async function () {
+      const { token, bob, alice, encTransferInput, transferValue } = await setupTransferAndCallFixture();
+
+      await token.mint(alice.address, 1_000_000n);
+
+      await prepExpectERC7984BalancesChange(token, bob.address);
+      await prepExpectERC7984BalancesChange(token, alice.address);
+
+      const tx = await token
+        .connect(bob)
+        [
+          "confidentialTransferAndCall(address,(uint256,uint8,uint8,bytes),bytes)"
+        ](alice.address, encTransferInput, "0x");
+
+      await expect(tx).to.emit(token, "ConfidentialTransfer");
+
+      // EOA always returns success, so transfer goes through
+      await expectERC7984BalancesChange(token, bob.address, -1n * transferValue);
+      await expectERC7984BalancesChange(token, alice.address, transferValue);
+    });
+
+    it("should revert with custom error from callback", async function () {
+      const { token, bob, receiver, encTransferInput } = await setupTransferAndCallFixture();
+
+      const callData = ethers.AbiCoder.defaultAbiCoder().encode(["uint8"], [2]);
+
+      await expect(
+        token
+          .connect(bob)
+          [
+            "confidentialTransferAndCall(address,(uint256,uint8,uint8,bytes),bytes)"
+          ](await receiver.getAddress(), encTransferInput, callData),
+      )
+        .to.be.revertedWithCustomError(receiver, "InvalidInput")
+        .withArgs(2);
+    });
+
+    it("should revert on transfer to zero address", async function () {
+      const { token, bob, encTransferInput } = await setupTransferAndCallFixture();
+
+      await expect(
+        token
+          .connect(bob)
+          [
+            "confidentialTransferAndCall(address,(uint256,uint8,uint8,bytes),bytes)"
+          ](ZeroAddress, encTransferInput, "0x"),
+      ).to.be.revertedWithCustomError(token, "ERC7984InvalidReceiver");
+    });
+  });
+
+  describe("confidentialTransferFromAndCall", function () {
+    const setupTransferFromAndCallFixture = async () => {
+      const { token, bob, alice, eve, bobClient, aliceClient, eveClient } = await setupFixture();
+
+      const mintValue = 10_000_000n;
+      await token.mint(bob.address, mintValue);
+      await token.mint(alice.address, mintValue);
+
+      const receiverFactory = await ethers.getContractFactory("MockERC7984Receiver");
+      const receiver = await receiverFactory.deploy();
+      await receiver.waitForDeployment();
+
+      return { token, bob, alice, eve, receiver, bobClient, aliceClient, eveClient };
+    };
+
+    it("should transfer from bob to receiver with callback (as operator, success)", async function () {
+      const { token, bob, alice, receiver, aliceClient } = await setupTransferFromAndCallFixture();
+
+      const receiverAddress = await receiver.getAddress();
+
+      const timestamp = (await ethers.provider.getBlock("latest"))!.timestamp + 100;
+      await token.connect(bob).setOperator(alice.address, timestamp);
+
+      const transferValue = 1_000_000n;
+      const [encTransferInput] = await aliceClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+
+      await prepExpectERC7984BalancesChange(token, bob.address);
+      await prepExpectERC7984BalancesChange(token, receiverAddress);
+
+      const callData = ethers.AbiCoder.defaultAbiCoder().encode(["uint8"], [1]);
+
+      const tx = await token
+        .connect(alice)
+        [
+          "confidentialTransferFromAndCall(address,address,(uint256,uint8,uint8,bytes),bytes)"
+        ](bob.address, receiverAddress, encTransferInput, callData);
+
+      await expect(tx).to.emit(receiver, "ConfidentialTransferCallback").withArgs(true);
+
+      await expectERC7984BalancesChange(token, bob.address, -1n * transferValue);
+      await expectERC7984BalancesChange(token, receiverAddress, transferValue);
+    });
+
+    it("should transfer from bob to receiver with callback (failure - refund)", async function () {
+      const { token, bob, alice, receiver, aliceClient } = await setupTransferFromAndCallFixture();
+
+      const receiverAddress = await receiver.getAddress();
+
+      const timestamp = (await ethers.provider.getBlock("latest"))!.timestamp + 100;
+      await token.connect(bob).setOperator(alice.address, timestamp);
+
+      const transferValue = 1_000_000n;
+      const [encTransferInput] = await aliceClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+
+      await prepExpectERC7984BalancesChange(token, bob.address);
+      await prepExpectERC7984BalancesChange(token, receiverAddress);
+
+      const callData = ethers.AbiCoder.defaultAbiCoder().encode(["uint8"], [0]);
+
+      await expect(
+        token
+          .connect(alice)
+          [
+            "confidentialTransferFromAndCall(address,address,(uint256,uint8,uint8,bytes),bytes)"
+          ](bob.address, receiverAddress, encTransferInput, callData),
+      ).to.emit(receiver, "ConfidentialTransferCallback");
+
+      // Failed callback: transfer should be refunded, balances unchanged
+      await expectERC7984BalancesChange(token, bob.address, 0n);
+      await expectERC7984BalancesChange(token, receiverAddress, 0n);
+    });
+
+    it("should transfer from bob to alice (EOA) with callback via eve as operator", async function () {
+      const { token, bob, alice, eve, eveClient } = await setupTransferFromAndCallFixture();
+
+      const timestamp = (await ethers.provider.getBlock("latest"))!.timestamp + 100;
+      await token.connect(bob).setOperator(eve.address, timestamp);
+
+      const transferValue = 1_000_000n;
+      const [encTransferInput] = await eveClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+
+      await prepExpectERC7984BalancesChange(token, bob.address);
+      await prepExpectERC7984BalancesChange(token, alice.address);
+
+      const tx = await token
+        .connect(eve)
+        [
+          "confidentialTransferFromAndCall(address,address,(uint256,uint8,uint8,bytes),bytes)"
+        ](bob.address, alice.address, encTransferInput, "0x");
+
+      await expect(tx).to.emit(token, "ConfidentialTransfer");
+
+      await expectERC7984BalancesChange(token, bob.address, -1n * transferValue);
+      await expectERC7984BalancesChange(token, alice.address, transferValue);
+    });
+
+    it("should revert without operator approval", async function () {
+      const { token, bob, alice, receiver, aliceClient } = await setupTransferFromAndCallFixture();
+
+      const transferValue = 1_000_000n;
+      const [encTransferInput] = await aliceClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+
+      const callData = ethers.AbiCoder.defaultAbiCoder().encode(["uint8"], [1]);
+
+      await expect(
+        token
+          .connect(alice)
+          [
+            "confidentialTransferFromAndCall(address,address,(uint256,uint8,uint8,bytes),bytes)"
+          ](bob.address, await receiver.getAddress(), encTransferInput, callData),
+      ).to.be.revertedWithCustomError(token, "ERC7984UnauthorizedSpender");
+    });
+
+    it("should revert with custom error from callback", async function () {
+      const { token, bob, alice, receiver, aliceClient } = await setupTransferFromAndCallFixture();
+
+      const timestamp = (await ethers.provider.getBlock("latest"))!.timestamp + 100;
+      await token.connect(bob).setOperator(alice.address, timestamp);
+
+      const transferValue = 1_000_000n;
+      const [encTransferInput] = await aliceClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+
+      const callData = ethers.AbiCoder.defaultAbiCoder().encode(["uint8"], [2]);
+
+      await expect(
+        token
+          .connect(alice)
+          [
+            "confidentialTransferFromAndCall(address,address,(uint256,uint8,uint8,bytes),bytes)"
+          ](bob.address, await receiver.getAddress(), encTransferInput, callData),
+      )
+        .to.be.revertedWithCustomError(receiver, "InvalidInput")
+        .withArgs(2);
+    });
+
+    it("should revert on transfer to zero address", async function () {
+      const { token, bob, alice, aliceClient } = await setupTransferFromAndCallFixture();
+
+      const timestamp = (await ethers.provider.getBlock("latest"))!.timestamp + 100;
+      await token.connect(bob).setOperator(alice.address, timestamp);
+
+      const transferValue = 1_000_000n;
+      const [encTransferInput] = await aliceClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+
+      await expect(
+        token
+          .connect(alice)
+          [
+            "confidentialTransferFromAndCall(address,address,(uint256,uint8,uint8,bytes),bytes)"
+          ](bob.address, ZeroAddress, encTransferInput, "0x"),
+      ).to.be.revertedWithCustomError(token, "ERC7984InvalidReceiver");
+    });
+  });
+
+  describe("disclose", function () {
+    it("should emit AmountDiscloseRequested on requestDiscloseEncryptedAmount", async function () {
+      const { token, bob } = await setupFixture();
+
+      await token.mint(bob.address, 1_000_000n);
+
+      const balanceHash = await token.confidentialBalanceOf(bob.address);
+
+      await expect(token.connect(bob).requestDiscloseEncryptedAmount(balanceHash)).to.emit(
+        token,
+        "AmountDiscloseRequested",
+      );
+    });
+  });
+});
+
+async function getIERC7984InterfaceId(): Promise<string> {
+  const selectors = [
+    "name()",
+    "symbol()",
+    "decimals()",
+    "contractURI()",
+    "confidentialTotalSupply()",
+    "confidentialBalanceOf(address)",
+    "isOperator(address,address)",
+    "setOperator(address,uint48)",
+    "confidentialTransfer(address,(uint256,uint8,uint8,bytes))",
+    "confidentialTransfer(address,bytes32)",
+    "confidentialTransferFrom(address,address,(uint256,uint8,uint8,bytes))",
+    "confidentialTransferFrom(address,address,bytes32)",
+    "confidentialTransferAndCall(address,(uint256,uint8,uint8,bytes),bytes)",
+    "confidentialTransferAndCall(address,bytes32,bytes)",
+    "confidentialTransferFromAndCall(address,address,(uint256,uint8,uint8,bytes),bytes)",
+    "confidentialTransferFromAndCall(address,address,bytes32,bytes)",
+  ];
+
+  let interfaceId = 0n;
+  for (const sig of selectors) {
+    const hash = ethers.keccak256(ethers.toUtf8Bytes(sig));
+    const selector = BigInt(hash.slice(0, 10));
+    interfaceId ^= selector;
+  }
+
+  return "0x" + interfaceId.toString(16).padStart(8, "0");
+}

--- a/test/ERC7984ERC20Wrapper.test.ts
+++ b/test/ERC7984ERC20Wrapper.test.ts
@@ -1,0 +1,316 @@
+import { expect } from "chai";
+import hre, { ethers } from "hardhat";
+import { ERC7984ERC20Wrapper_Harness, ERC20_Harness } from "../typechain-types";
+import { Encryptable } from "@cofhe/sdk";
+import {
+  expectERC20BalancesChange,
+  expectERC7984BalancesChange,
+  prepExpectERC20BalancesChange,
+  prepExpectERC7984BalancesChange,
+} from "./utils";
+import { ZeroAddress, ContractTransactionResponse } from "ethers";
+
+async function getUnshieldRequestId(
+  tx: ContractTransactionResponse,
+  contract: ERC7984ERC20Wrapper_Harness,
+): Promise<string> {
+  const receipt = await tx.wait();
+  for (const log of receipt!.logs) {
+    try {
+      const parsed = contract.interface.parseLog({ topics: log.topics as string[], data: log.data });
+      if (parsed?.name === "Unshielded") {
+        return parsed.args.unshieldRequestId;
+      }
+    } catch {}
+  }
+  throw new Error("Unshielded event not found");
+}
+
+describe("ERC7984ERC20Wrapper", function () {
+  const deployContracts = async () => {
+    const wBTCFactory = await ethers.getContractFactory("ERC20_Harness");
+    const wBTC = (await wBTCFactory.deploy("Wrapped BTC", "wBTC", 8)) as ERC20_Harness;
+    await wBTC.waitForDeployment();
+
+    const eBTCFactory = await ethers.getContractFactory("ERC7984ERC20Wrapper_Harness");
+    const eBTC = (await eBTCFactory.deploy(
+      wBTC.target,
+      "ERC7984 Wrapped BTC",
+      "eBTC",
+      "https://example.com/ebtc.json",
+    )) as ERC7984ERC20Wrapper_Harness;
+    await eBTC.waitForDeployment();
+
+    return { wBTC, eBTC };
+  };
+
+  async function setupFixture() {
+    const [owner, bob, alice, eve] = await ethers.getSigners();
+    const { wBTC, eBTC } = await deployContracts();
+
+    const ownerClient = await hre.cofhe.createClientWithBatteries(owner);
+    const bobClient = await hre.cofhe.createClientWithBatteries(bob);
+    const aliceClient = await hre.cofhe.createClientWithBatteries(alice);
+    const eveClient = await hre.cofhe.createClientWithBatteries(eve);
+
+    return { ownerClient, bobClient, aliceClient, eveClient, owner, bob, alice, eve, wBTC, eBTC };
+  }
+
+  // wBTC has 8 decimals → rate = 100, confidential decimals = 6
+  const conversionRate = 100n;
+
+  describe("initialization", function () {
+    it("should be constructed correctly", async function () {
+      const { wBTC, eBTC } = await setupFixture();
+
+      expect(await eBTC.name()).to.equal("ERC7984 Wrapped BTC");
+      expect(await eBTC.symbol()).to.equal("eBTC");
+      expect(await eBTC.decimals()).to.equal(6);
+      expect(await eBTC.contractURI()).to.equal("https://example.com/ebtc.json");
+      expect(await eBTC.underlying()).to.equal(wBTC.target);
+      expect(await eBTC.rate()).to.equal(conversionRate);
+      expect(await eBTC.maxTotalSupply()).to.equal(BigInt("18446744073709551615")); // type(uint64).max
+      expect(await eBTC.inferredTotalSupply()).to.equal(0n);
+    });
+
+    it("should support expected interfaces", async function () {
+      const { eBTC } = await setupFixture();
+
+      // ERC165
+      expect(await eBTC.supportsInterface("0x01ffc9a7")).to.equal(true);
+      // IERC1363Receiver
+      expect(await eBTC.supportsInterface("0x88a7ca5c")).to.equal(true);
+      // Random unsupported
+      expect(await eBTC.supportsInterface("0xdeadbeef")).to.equal(false);
+    });
+
+    it("should allow symbol update", async function () {
+      const { eBTC } = await setupFixture();
+
+      await expect(eBTC.updateSymbol("encBTC")).to.emit(eBTC, "SymbolUpdated").withArgs("encBTC");
+      expect(await eBTC.symbol()).to.equal("encBTC");
+    });
+  });
+
+  describe("shield (ERC20 → ERC7984)", function () {
+    it("should shield tokens successfully", async function () {
+      const { eBTC, bob, wBTC } = await setupFixture();
+
+      const mintValue = BigInt(10e8);
+      const shieldValue = BigInt(1e8);
+      const confidentialValue = shieldValue / conversionRate; // 1e6
+
+      await wBTC.mint(bob, mintValue);
+      await wBTC.connect(bob).approve(eBTC.target, mintValue);
+
+      await prepExpectERC20BalancesChange(wBTC, bob.address);
+      await prepExpectERC7984BalancesChange(eBTC, bob.address);
+
+      await expect(eBTC.connect(bob).shield(bob, shieldValue)).to.emit(eBTC, "ConfidentialTransfer");
+
+      await expectERC20BalancesChange(wBTC, bob.address, -1n * shieldValue);
+      await expectERC7984BalancesChange(eBTC, bob.address, confidentialValue);
+
+      await hre.cofhe.mocks.expectPlaintext(await eBTC.confidentialTotalSupply(), confidentialValue);
+      expect(await eBTC.inferredTotalSupply()).to.equal(confidentialValue);
+    });
+
+    it("should shield to a different recipient", async function () {
+      const { eBTC, bob, alice, wBTC } = await setupFixture();
+
+      const shieldValue = BigInt(1e8);
+      const confidentialValue = shieldValue / conversionRate;
+
+      await wBTC.mint(bob, shieldValue);
+      await wBTC.connect(bob).approve(eBTC.target, shieldValue);
+
+      await prepExpectERC7984BalancesChange(eBTC, alice.address);
+
+      await eBTC.connect(bob).shield(alice, shieldValue);
+
+      await expectERC7984BalancesChange(eBTC, alice.address, confidentialValue);
+    });
+
+    it("should truncate amount to nearest rate multiple", async function () {
+      const { eBTC, bob, wBTC } = await setupFixture();
+
+      const shieldValue = BigInt(1e8) + 50n; // 50 extra (below rate of 100)
+      const alignedValue = BigInt(1e8);
+      const confidentialValue = alignedValue / conversionRate;
+
+      await wBTC.mint(bob, shieldValue);
+      await wBTC.connect(bob).approve(eBTC.target, shieldValue);
+
+      await prepExpectERC20BalancesChange(wBTC, bob.address);
+      await prepExpectERC7984BalancesChange(eBTC, bob.address);
+
+      await eBTC.connect(bob).shield(bob, shieldValue);
+
+      // Only the aligned portion is transferred
+      await expectERC20BalancesChange(wBTC, bob.address, -1n * alignedValue);
+      await expectERC7984BalancesChange(eBTC, bob.address, confidentialValue);
+    });
+
+    it("should shield cumulatively", async function () {
+      const { eBTC, bob, wBTC } = await setupFixture();
+
+      const shieldValue = BigInt(1e8);
+      const confidentialValue = shieldValue / conversionRate;
+
+      await wBTC.mint(bob, BigInt(10e8));
+      await wBTC.connect(bob).approve(eBTC.target, BigInt(10e8));
+
+      await eBTC.connect(bob).shield(bob, shieldValue);
+
+      await prepExpectERC7984BalancesChange(eBTC, bob.address);
+
+      await eBTC.connect(bob).shield(bob, shieldValue);
+
+      await expectERC7984BalancesChange(eBTC, bob.address, confidentialValue);
+      await hre.cofhe.mocks.expectPlaintext(await eBTC.confidentialTotalSupply(), confidentialValue * 2n);
+    });
+  });
+
+  describe("unshield & claimUnshielded (ERC7984 → ERC20)", function () {
+    async function setupShieldedFixture() {
+      const fixture = await setupFixture();
+      const { eBTC, bob, wBTC } = fixture;
+
+      const mintValue = BigInt(10e8);
+      await wBTC.mint(bob, mintValue);
+      await wBTC.connect(bob).approve(eBTC.target, mintValue);
+      await eBTC.connect(bob).shield(bob, mintValue);
+
+      return fixture;
+    }
+
+    it("should complete unshield and claim flow", async function () {
+      const { eBTC, bob, alice, wBTC, bobClient } = await setupShieldedFixture();
+
+      const unshieldConfidentialValue = 1_000_000n;
+      const unshieldERC20Value = unshieldConfidentialValue * conversionRate; // 1e8
+
+      const [encAmount] = await bobClient.encryptInputs([Encryptable.uint64(unshieldConfidentialValue)]).execute();
+
+      await prepExpectERC7984BalancesChange(eBTC, bob.address);
+
+      const tx = await eBTC
+        .connect(bob)
+        ["unshield(address,address,(uint256,uint8,uint8,bytes))"](bob.address, alice.address, encAmount);
+
+      await expect(tx).to.emit(eBTC, "Unshielded");
+      await expectERC7984BalancesChange(eBTC, bob.address, -1n * unshieldConfidentialValue);
+
+      const unshieldRequestId = await getUnshieldRequestId(tx, eBTC);
+
+      expect(await eBTC.unshieldRequester(unshieldRequestId)).to.equal(alice.address);
+
+      // Time travel past decryption delay
+      await hre.network.provider.send("evm_increaseTime", [11]);
+      await hre.network.provider.send("evm_mine");
+
+      const decryption = await bobClient.decryptForTx(unshieldRequestId).withoutPermit().execute();
+
+      await prepExpectERC20BalancesChange(wBTC, alice.address);
+
+      await expect(
+        eBTC.connect(bob).claimUnshielded(unshieldRequestId, decryption.decryptedValue, decryption.signature),
+      ).to.emit(eBTC, "ClaimedUnshielded");
+
+      await expectERC20BalancesChange(wBTC, alice.address, unshieldERC20Value);
+
+      // Request is cleared
+      expect(await eBTC.unshieldRequester(unshieldRequestId)).to.equal(ZeroAddress);
+    });
+
+    it("should allow unshield by operator", async function () {
+      const { eBTC, bob, alice, wBTC, aliceClient } = await setupShieldedFixture();
+
+      const unshieldConfidentialValue = 1_000_000n;
+      const unshieldERC20Value = unshieldConfidentialValue * conversionRate;
+
+      const timestamp = (await ethers.provider.getBlock("latest"))!.timestamp + 100;
+      await eBTC.connect(bob).setOperator(alice.address, timestamp);
+
+      const [encAmount] = await aliceClient.encryptInputs([Encryptable.uint64(unshieldConfidentialValue)]).execute();
+
+      await prepExpectERC7984BalancesChange(eBTC, bob.address);
+
+      const tx = await eBTC
+        .connect(alice)
+        ["unshield(address,address,(uint256,uint8,uint8,bytes))"](bob.address, alice.address, encAmount);
+
+      await expect(tx).to.emit(eBTC, "Unshielded");
+      await expectERC7984BalancesChange(eBTC, bob.address, -1n * unshieldConfidentialValue);
+
+      const unshieldRequestId = await getUnshieldRequestId(tx, eBTC);
+
+      await hre.network.provider.send("evm_increaseTime", [11]);
+      await hre.network.provider.send("evm_mine");
+
+      const decryption = await aliceClient.decryptForTx(unshieldRequestId).withoutPermit().execute();
+
+      await prepExpectERC20BalancesChange(wBTC, alice.address);
+
+      await eBTC.connect(alice).claimUnshielded(unshieldRequestId, decryption.decryptedValue, decryption.signature);
+
+      await expectERC20BalancesChange(wBTC, alice.address, unshieldERC20Value);
+    });
+  });
+
+  describe("unshield reverts", function () {
+    it("should revert on zero address receiver", async function () {
+      const { eBTC, bob, wBTC, bobClient } = await setupFixture();
+
+      const mintValue = BigInt(10e8);
+      await wBTC.mint(bob, mintValue);
+      await wBTC.connect(bob).approve(eBTC.target, mintValue);
+      await eBTC.connect(bob).shield(bob, mintValue);
+
+      const [encAmount] = await bobClient.encryptInputs([Encryptable.uint64(1_000_000n)]).execute();
+
+      await expect(
+        eBTC
+          .connect(bob)
+          ["unshield(address,address,(uint256,uint8,uint8,bytes))"](bob.address, ZeroAddress, encAmount),
+      ).to.be.revertedWithCustomError(eBTC, "ERC7984InvalidReceiver");
+    });
+
+    it("should revert when caller is not operator", async function () {
+      const { eBTC, bob, alice, wBTC, aliceClient } = await setupFixture();
+
+      const mintValue = BigInt(10e8);
+      await wBTC.mint(bob, mintValue);
+      await wBTC.connect(bob).approve(eBTC.target, mintValue);
+      await eBTC.connect(bob).shield(bob, mintValue);
+
+      const [encAmount] = await aliceClient.encryptInputs([Encryptable.uint64(1_000_000n)]).execute();
+
+      await expect(
+        eBTC
+          .connect(alice)
+          ["unshield(address,address,(uint256,uint8,uint8,bytes))"](bob.address, alice.address, encAmount),
+      ).to.be.revertedWithCustomError(eBTC, "ERC7984UnauthorizedSpender");
+    });
+  });
+
+  describe("claimUnshielded reverts", function () {
+    it("should revert on invalid request id", async function () {
+      const { eBTC } = await setupFixture();
+
+      await expect(
+        eBTC.claimUnshielded(ethers.ZeroHash, 0n, new Uint8Array(0)),
+      ).to.be.revertedWithCustomError(eBTC, "InvalidUnshieldRequest");
+    });
+  });
+
+  describe("onTransferReceived", function () {
+    it("should revert when called by non-underlying token", async function () {
+      const { eBTC, bob } = await setupFixture();
+
+      await expect(
+        eBTC.connect(bob).onTransferReceived(bob.address, bob.address, 1000n, "0x"),
+      ).to.be.revertedWithCustomError(eBTC, "ERC7984UnauthorizedCaller");
+    });
+  });
+});

--- a/test/ERC7984ERC20Wrapper.test.ts
+++ b/test/ERC7984ERC20Wrapper.test.ts
@@ -1,7 +1,6 @@
 import { expect } from "chai";
 import hre, { ethers } from "hardhat";
 import { ERC7984ERC20Wrapper_Harness, ERC20_Harness } from "../typechain-types";
-import { Encryptable } from "@cofhe/sdk";
 import {
   expectERC20BalancesChange,
   expectERC7984BalancesChange,
@@ -19,7 +18,7 @@ async function getUnshieldRequestId(
     try {
       const parsed = contract.interface.parseLog({ topics: log.topics as string[], data: log.data });
       if (parsed?.name === "Unshielded") {
-        return parsed.args.unshieldRequestId;
+        return parsed.args.amount;
       }
     } catch {}
   }
@@ -82,13 +81,6 @@ describe("ERC7984ERC20Wrapper", function () {
       expect(await eBTC.supportsInterface("0x88a7ca5c")).to.equal(true);
       // Random unsupported
       expect(await eBTC.supportsInterface("0xdeadbeef")).to.equal(false);
-    });
-
-    it("should allow symbol update", async function () {
-      const { eBTC } = await setupFixture();
-
-      await expect(eBTC.updateSymbol("encBTC")).to.emit(eBTC, "SymbolUpdated").withArgs("encBTC");
-      expect(await eBTC.symbol()).to.equal("encBTC");
     });
   });
 
@@ -190,20 +182,24 @@ describe("ERC7984ERC20Wrapper", function () {
       const unshieldConfidentialValue = 1_000_000n;
       const unshieldERC20Value = unshieldConfidentialValue * conversionRate; // 1e8
 
-      const [encAmount] = await bobClient.encryptInputs([Encryptable.uint64(unshieldConfidentialValue)]).execute();
-
       await prepExpectERC7984BalancesChange(eBTC, bob.address);
 
-      const tx = await eBTC
-        .connect(bob)
-        ["unshield(address,address,(uint256,uint8,uint8,bytes))"](bob.address, alice.address, encAmount);
+      const tx = await eBTC.connect(bob).unshield(bob.address, alice.address, unshieldConfidentialValue);
 
       await expect(tx).to.emit(eBTC, "Unshielded");
       await expectERC7984BalancesChange(eBTC, bob.address, -1n * unshieldConfidentialValue);
 
       const unshieldRequestId = await getUnshieldRequestId(tx, eBTC);
 
-      expect(await eBTC.unshieldRequester(unshieldRequestId)).to.equal(alice.address);
+      // Verify claim was created via getClaim
+      const pendingClaim = await eBTC.getClaim(unshieldRequestId);
+      expect(pendingClaim.to).to.equal(alice.address);
+      expect(pendingClaim.claimed).to.equal(false);
+
+      // Verify getUserClaims tracks the pending claim
+      const aliceClaims = await eBTC.getUserClaims(alice.address);
+      expect(aliceClaims.length).to.equal(1);
+      expect(aliceClaims[0].ctHash).to.equal(unshieldRequestId);
 
       // Time travel past decryption delay
       await hre.network.provider.send("evm_increaseTime", [11]);
@@ -219,8 +215,12 @@ describe("ERC7984ERC20Wrapper", function () {
 
       await expectERC20BalancesChange(wBTC, alice.address, unshieldERC20Value);
 
-      // Request is cleared
-      expect(await eBTC.unshieldRequester(unshieldRequestId)).to.equal(ZeroAddress);
+      // Claim is marked as claimed and removed from user's pending claims
+      const claimedClaim = await eBTC.getClaim(unshieldRequestId);
+      expect(claimedClaim.claimed).to.equal(true);
+
+      const aliceClaimsAfter = await eBTC.getUserClaims(alice.address);
+      expect(aliceClaimsAfter.length).to.equal(0);
     });
 
     it("should allow unshield by operator", async function () {
@@ -232,13 +232,9 @@ describe("ERC7984ERC20Wrapper", function () {
       const timestamp = (await ethers.provider.getBlock("latest"))!.timestamp + 100;
       await eBTC.connect(bob).setOperator(alice.address, timestamp);
 
-      const [encAmount] = await aliceClient.encryptInputs([Encryptable.uint64(unshieldConfidentialValue)]).execute();
-
       await prepExpectERC7984BalancesChange(eBTC, bob.address);
 
-      const tx = await eBTC
-        .connect(alice)
-        ["unshield(address,address,(uint256,uint8,uint8,bytes))"](bob.address, alice.address, encAmount);
+      const tx = await eBTC.connect(alice).unshield(bob.address, alice.address, unshieldConfidentialValue);
 
       await expect(tx).to.emit(eBTC, "Unshielded");
       await expectERC7984BalancesChange(eBTC, bob.address, -1n * unshieldConfidentialValue);
@@ -256,41 +252,77 @@ describe("ERC7984ERC20Wrapper", function () {
 
       await expectERC20BalancesChange(wBTC, alice.address, unshieldERC20Value);
     });
+
+    it("should support batch claim", async function () {
+      const { eBTC, bob, alice, wBTC, bobClient } = await setupShieldedFixture();
+
+      const unshieldAmount1 = 500_000n;
+      const unshieldAmount2 = 300_000n;
+
+      // Create first unshield
+      const tx1 = await eBTC.connect(bob).unshield(bob.address, alice.address, unshieldAmount1);
+      const requestId1 = await getUnshieldRequestId(tx1, eBTC);
+
+      // Create second unshield
+      const tx2 = await eBTC.connect(bob).unshield(bob.address, alice.address, unshieldAmount2);
+      const requestId2 = await getUnshieldRequestId(tx2, eBTC);
+
+      // Alice should have 2 pending claims
+      const pendingClaims = await eBTC.getUserClaims(alice.address);
+      expect(pendingClaims.length).to.equal(2);
+
+      await hre.network.provider.send("evm_increaseTime", [11]);
+      await hre.network.provider.send("evm_mine");
+
+      const dec1 = await bobClient.decryptForTx(requestId1).withoutPermit().execute();
+      const dec2 = await bobClient.decryptForTx(requestId2).withoutPermit().execute();
+
+      await prepExpectERC20BalancesChange(wBTC, alice.address);
+
+      await eBTC
+        .connect(bob)
+        .claimUnshieldedBatch(
+          [requestId1, requestId2],
+          [dec1.decryptedValue, dec2.decryptedValue],
+          [dec1.signature, dec2.signature],
+        );
+
+      const totalERC20Value = (unshieldAmount1 + unshieldAmount2) * conversionRate;
+      await expectERC20BalancesChange(wBTC, alice.address, totalERC20Value);
+
+      // All claims cleared
+      const claimsAfter = await eBTC.getUserClaims(alice.address);
+      expect(claimsAfter.length).to.equal(0);
+    });
   });
 
   describe("unshield reverts", function () {
     it("should revert on zero address receiver", async function () {
-      const { eBTC, bob, wBTC, bobClient } = await setupFixture();
+      const { eBTC, bob, wBTC } = await setupFixture();
 
       const mintValue = BigInt(10e8);
       await wBTC.mint(bob, mintValue);
       await wBTC.connect(bob).approve(eBTC.target, mintValue);
       await eBTC.connect(bob).shield(bob, mintValue);
 
-      const [encAmount] = await bobClient.encryptInputs([Encryptable.uint64(1_000_000n)]).execute();
-
-      await expect(
-        eBTC
-          .connect(bob)
-          ["unshield(address,address,(uint256,uint8,uint8,bytes))"](bob.address, ZeroAddress, encAmount),
-      ).to.be.revertedWithCustomError(eBTC, "ERC7984InvalidReceiver");
+      await expect(eBTC.connect(bob).unshield(bob.address, ZeroAddress, 1_000_000n)).to.be.revertedWithCustomError(
+        eBTC,
+        "ERC7984InvalidReceiver",
+      );
     });
 
     it("should revert when caller is not operator", async function () {
-      const { eBTC, bob, alice, wBTC, aliceClient } = await setupFixture();
+      const { eBTC, bob, alice, wBTC } = await setupFixture();
 
       const mintValue = BigInt(10e8);
       await wBTC.mint(bob, mintValue);
       await wBTC.connect(bob).approve(eBTC.target, mintValue);
       await eBTC.connect(bob).shield(bob, mintValue);
 
-      const [encAmount] = await aliceClient.encryptInputs([Encryptable.uint64(1_000_000n)]).execute();
-
-      await expect(
-        eBTC
-          .connect(alice)
-          ["unshield(address,address,(uint256,uint8,uint8,bytes))"](bob.address, alice.address, encAmount),
-      ).to.be.revertedWithCustomError(eBTC, "ERC7984UnauthorizedSpender");
+      await expect(eBTC.connect(alice).unshield(bob.address, alice.address, 1_000_000n)).to.be.revertedWithCustomError(
+        eBTC,
+        "ERC7984UnauthorizedSpender",
+      );
     });
   });
 
@@ -298,9 +330,35 @@ describe("ERC7984ERC20Wrapper", function () {
     it("should revert on invalid request id", async function () {
       const { eBTC } = await setupFixture();
 
+      await expect(eBTC.claimUnshielded(ethers.ZeroHash, 0n, new Uint8Array(0))).to.be.revertedWithCustomError(
+        eBTC,
+        "ClaimNotFound",
+      );
+    });
+
+    it("should revert when claiming already claimed request", async function () {
+      const { eBTC, bob, alice, wBTC, bobClient } = await setupFixture();
+
+      const mintValue = BigInt(10e8);
+      await wBTC.mint(bob, mintValue);
+      await wBTC.connect(bob).approve(eBTC.target, mintValue);
+      await eBTC.connect(bob).shield(bob, mintValue);
+
+      const tx = await eBTC.connect(bob).unshield(bob.address, alice.address, 1_000_000n);
+      const requestId = await getUnshieldRequestId(tx, eBTC);
+
+      await hre.network.provider.send("evm_increaseTime", [11]);
+      await hre.network.provider.send("evm_mine");
+
+      const decryption = await bobClient.decryptForTx(requestId).withoutPermit().execute();
+
+      // First claim succeeds
+      await eBTC.connect(bob).claimUnshielded(requestId, decryption.decryptedValue, decryption.signature);
+
+      // Second claim reverts
       await expect(
-        eBTC.claimUnshielded(ethers.ZeroHash, 0n, new Uint8Array(0)),
-      ).to.be.revertedWithCustomError(eBTC, "InvalidUnshieldRequest");
+        eBTC.connect(bob).claimUnshielded(requestId, decryption.decryptedValue, decryption.signature),
+      ).to.be.revertedWithCustomError(eBTC, "AlreadyClaimed");
     });
   });
 

--- a/test/ERC7984NativeWrapper.test.ts
+++ b/test/ERC7984NativeWrapper.test.ts
@@ -1,7 +1,6 @@
 import { expect } from "chai";
 import hre, { ethers } from "hardhat";
 import { ERC7984NativeWrapper_Harness, WETH_Harness } from "../typechain-types";
-import { Encryptable } from "@cofhe/sdk";
 import { expectERC7984BalancesChange, prepExpectERC7984BalancesChange } from "./utils";
 import { ZeroAddress, ContractTransactionResponse } from "ethers";
 
@@ -14,7 +13,7 @@ async function getUnshieldRequestId(
     try {
       const parsed = contract.interface.parseLog({ topics: log.topics as string[], data: log.data });
       if (parsed?.name === "Unshielded") {
-        return parsed.args.unshieldRequestId;
+        return parsed.args.amount;
       }
     } catch {}
   }
@@ -75,13 +74,6 @@ describe("ERC7984NativeWrapper", function () {
       expect(await eETH.supportsInterface("0x01ffc9a7")).to.equal(true);
       // Random unsupported
       expect(await eETH.supportsInterface("0xdeadbeef")).to.equal(false);
-    });
-
-    it("should allow symbol update", async function () {
-      const { eETH } = await setupFixture();
-
-      await expect(eETH.updateSymbol("encETH")).to.emit(eETH, "SymbolUpdated").withArgs("encETH");
-      expect(await eETH.symbol()).to.equal("encETH");
     });
   });
 
@@ -144,9 +136,10 @@ describe("ERC7984NativeWrapper", function () {
       await wETH.connect(bob).deposit({ value: dust });
       await wETH.connect(bob).approve(eETH.target, dust);
 
-      await expect(
-        eETH.connect(bob).shieldWrappedNative(bob, dust),
-      ).to.be.revertedWithCustomError(eETH, "AmountTooSmallForConfidentialPrecision");
+      await expect(eETH.connect(bob).shieldWrappedNative(bob, dust)).to.be.revertedWithCustomError(
+        eETH,
+        "AmountTooSmallForConfidentialPrecision",
+      );
     });
 
     it("should default to msg.sender when to is zero address", async function () {
@@ -201,9 +194,10 @@ describe("ERC7984NativeWrapper", function () {
 
       const dust = conversionRate - 1n;
 
-      await expect(
-        eETH.connect(bob).shieldNative(bob, { value: dust }),
-      ).to.be.revertedWithCustomError(eETH, "AmountTooSmallForConfidentialPrecision");
+      await expect(eETH.connect(bob).shieldNative(bob, { value: dust })).to.be.revertedWithCustomError(
+        eETH,
+        "AmountTooSmallForConfidentialPrecision",
+      );
     });
 
     it("should default to msg.sender when to is zero address", async function () {
@@ -237,20 +231,24 @@ describe("ERC7984NativeWrapper", function () {
       const unshieldConfidentialValue = 1_000_000n;
       const unshieldNativeValue = unshieldConfidentialValue * conversionRate; // 1e18
 
-      const [encAmount] = await bobClient.encryptInputs([Encryptable.uint64(unshieldConfidentialValue)]).execute();
-
       await prepExpectERC7984BalancesChange(eETH, bob.address);
 
-      const tx = await eETH
-        .connect(bob)
-        ["unshield(address,address,(uint256,uint8,uint8,bytes))"](bob.address, alice.address, encAmount);
+      const tx = await eETH.connect(bob).unshield(bob.address, alice.address, unshieldConfidentialValue);
 
       await expect(tx).to.emit(eETH, "Unshielded");
       await expectERC7984BalancesChange(eETH, bob.address, -1n * unshieldConfidentialValue);
 
       const unshieldRequestId = await getUnshieldRequestId(tx, eETH);
 
-      expect(await eETH.unshieldRequester(unshieldRequestId)).to.equal(alice.address);
+      // Verify claim was created via getClaim
+      const pendingClaim = await eETH.getClaim(unshieldRequestId);
+      expect(pendingClaim.to).to.equal(alice.address);
+      expect(pendingClaim.claimed).to.equal(false);
+
+      // Verify getUserClaims tracks the pending claim
+      const aliceClaims = await eETH.getUserClaims(alice.address);
+      expect(aliceClaims.length).to.equal(1);
+      expect(aliceClaims[0].ctHash).to.equal(unshieldRequestId);
 
       // Time travel past decryption delay
       await hre.network.provider.send("evm_increaseTime", [11]);
@@ -267,8 +265,12 @@ describe("ERC7984NativeWrapper", function () {
       const aliceBalanceAfter = await ethers.provider.getBalance(alice.address);
       expect(aliceBalanceAfter - aliceBalanceBefore).to.equal(unshieldNativeValue);
 
-      // Request is cleared
-      expect(await eETH.unshieldRequester(unshieldRequestId)).to.equal(ZeroAddress);
+      // Claim is marked as claimed and removed from user's pending claims
+      const claimedClaim = await eETH.getClaim(unshieldRequestId);
+      expect(claimedClaim.claimed).to.equal(true);
+
+      const aliceClaimsAfter = await eETH.getUserClaims(alice.address);
+      expect(aliceClaimsAfter.length).to.equal(0);
     });
 
     it("should allow unshield by operator", async function () {
@@ -280,13 +282,9 @@ describe("ERC7984NativeWrapper", function () {
       const timestamp = (await ethers.provider.getBlock("latest"))!.timestamp + 100;
       await eETH.connect(bob).setOperator(alice.address, timestamp);
 
-      const [encAmount] = await aliceClient.encryptInputs([Encryptable.uint64(unshieldConfidentialValue)]).execute();
-
       await prepExpectERC7984BalancesChange(eETH, bob.address);
 
-      const tx = await eETH
-        .connect(alice)
-        ["unshield(address,address,(uint256,uint8,uint8,bytes))"](bob.address, alice.address, encAmount);
+      const tx = await eETH.connect(alice).unshield(bob.address, alice.address, unshieldConfidentialValue);
 
       await expect(tx).to.emit(eETH, "Unshielded");
       await expectERC7984BalancesChange(eETH, bob.address, -1n * unshieldConfidentialValue);
@@ -305,35 +303,72 @@ describe("ERC7984NativeWrapper", function () {
       const aliceBalanceAfter = await ethers.provider.getBalance(alice.address);
       expect(aliceBalanceAfter - aliceBalanceBefore).to.equal(unshieldNativeValue);
     });
+
+    it("should support batch claim", async function () {
+      const { eETH, bob, alice, bobClient } = await setupShieldedFixture();
+
+      const unshieldAmount1 = 500_000n;
+      const unshieldAmount2 = 300_000n;
+
+      // Create first unshield
+      const tx1 = await eETH.connect(bob).unshield(bob.address, alice.address, unshieldAmount1);
+      const requestId1 = await getUnshieldRequestId(tx1, eETH);
+
+      // Create second unshield
+      const tx2 = await eETH.connect(bob).unshield(bob.address, alice.address, unshieldAmount2);
+      const requestId2 = await getUnshieldRequestId(tx2, eETH);
+
+      // Alice should have 2 pending claims
+      const pendingClaims = await eETH.getUserClaims(alice.address);
+      expect(pendingClaims.length).to.equal(2);
+
+      await hre.network.provider.send("evm_increaseTime", [11]);
+      await hre.network.provider.send("evm_mine");
+
+      const dec1 = await bobClient.decryptForTx(requestId1).withoutPermit().execute();
+      const dec2 = await bobClient.decryptForTx(requestId2).withoutPermit().execute();
+
+      const aliceBalanceBefore = await ethers.provider.getBalance(alice.address);
+
+      await eETH
+        .connect(bob)
+        .claimUnshieldedBatch(
+          [requestId1, requestId2],
+          [dec1.decryptedValue, dec2.decryptedValue],
+          [dec1.signature, dec2.signature],
+        );
+
+      const totalNativeValue = (unshieldAmount1 + unshieldAmount2) * conversionRate;
+      const aliceBalanceAfter = await ethers.provider.getBalance(alice.address);
+      expect(aliceBalanceAfter - aliceBalanceBefore).to.equal(totalNativeValue);
+
+      // All claims cleared
+      const claimsAfter = await eETH.getUserClaims(alice.address);
+      expect(claimsAfter.length).to.equal(0);
+    });
   });
 
   describe("unshield reverts", function () {
     it("should revert on zero address receiver", async function () {
-      const { eETH, bob, bobClient } = await setupFixture();
+      const { eETH, bob } = await setupFixture();
 
       await eETH.connect(bob).shieldNative(bob, { value: ethers.parseEther("10") });
 
-      const [encAmount] = await bobClient.encryptInputs([Encryptable.uint64(1_000_000n)]).execute();
-
-      await expect(
-        eETH
-          .connect(bob)
-          ["unshield(address,address,(uint256,uint8,uint8,bytes))"](bob.address, ZeroAddress, encAmount),
-      ).to.be.revertedWithCustomError(eETH, "ERC7984InvalidReceiver");
+      await expect(eETH.connect(bob).unshield(bob.address, ZeroAddress, 1_000_000n)).to.be.revertedWithCustomError(
+        eETH,
+        "ERC7984InvalidReceiver",
+      );
     });
 
     it("should revert when caller is not operator", async function () {
-      const { eETH, bob, alice, aliceClient } = await setupFixture();
+      const { eETH, bob, alice } = await setupFixture();
 
       await eETH.connect(bob).shieldNative(bob, { value: ethers.parseEther("10") });
 
-      const [encAmount] = await aliceClient.encryptInputs([Encryptable.uint64(1_000_000n)]).execute();
-
-      await expect(
-        eETH
-          .connect(alice)
-          ["unshield(address,address,(uint256,uint8,uint8,bytes))"](bob.address, alice.address, encAmount),
-      ).to.be.revertedWithCustomError(eETH, "ERC7984UnauthorizedSpender");
+      await expect(eETH.connect(alice).unshield(bob.address, alice.address, 1_000_000n)).to.be.revertedWithCustomError(
+        eETH,
+        "ERC7984UnauthorizedSpender",
+      );
     });
   });
 
@@ -341,9 +376,32 @@ describe("ERC7984NativeWrapper", function () {
     it("should revert on invalid request id", async function () {
       const { eETH } = await setupFixture();
 
+      await expect(eETH.claimUnshielded(ethers.ZeroHash, 0n, new Uint8Array(0))).to.be.revertedWithCustomError(
+        eETH,
+        "ClaimNotFound",
+      );
+    });
+
+    it("should revert when claiming already claimed request", async function () {
+      const { eETH, bob, alice, bobClient } = await setupFixture();
+
+      await eETH.connect(bob).shieldNative(bob, { value: ethers.parseEther("10") });
+
+      const tx = await eETH.connect(bob).unshield(bob.address, alice.address, 1_000_000n);
+      const requestId = await getUnshieldRequestId(tx, eETH);
+
+      await hre.network.provider.send("evm_increaseTime", [11]);
+      await hre.network.provider.send("evm_mine");
+
+      const decryption = await bobClient.decryptForTx(requestId).withoutPermit().execute();
+
+      // First claim succeeds
+      await eETH.connect(bob).claimUnshielded(requestId, decryption.decryptedValue, decryption.signature);
+
+      // Second claim reverts
       await expect(
-        eETH.claimUnshielded(ethers.ZeroHash, 0n, new Uint8Array(0)),
-      ).to.be.revertedWithCustomError(eETH, "InvalidUnshieldRequest");
+        eETH.connect(bob).claimUnshielded(requestId, decryption.decryptedValue, decryption.signature),
+      ).to.be.revertedWithCustomError(eETH, "AlreadyClaimed");
     });
   });
 });

--- a/test/ERC7984NativeWrapper.test.ts
+++ b/test/ERC7984NativeWrapper.test.ts
@@ -1,0 +1,349 @@
+import { expect } from "chai";
+import hre, { ethers } from "hardhat";
+import { ERC7984NativeWrapper_Harness, WETH_Harness } from "../typechain-types";
+import { Encryptable } from "@cofhe/sdk";
+import { expectERC7984BalancesChange, prepExpectERC7984BalancesChange } from "./utils";
+import { ZeroAddress, ContractTransactionResponse } from "ethers";
+
+async function getUnshieldRequestId(
+  tx: ContractTransactionResponse,
+  contract: ERC7984NativeWrapper_Harness,
+): Promise<string> {
+  const receipt = await tx.wait();
+  for (const log of receipt!.logs) {
+    try {
+      const parsed = contract.interface.parseLog({ topics: log.topics as string[], data: log.data });
+      if (parsed?.name === "Unshielded") {
+        return parsed.args.unshieldRequestId;
+      }
+    } catch {}
+  }
+  throw new Error("Unshielded event not found");
+}
+
+describe("ERC7984NativeWrapper", function () {
+  const deployContracts = async () => {
+    const wETHFactory = await ethers.getContractFactory("WETH_Harness");
+    const wETH = (await wETHFactory.deploy()) as WETH_Harness;
+    await wETH.waitForDeployment();
+
+    const eETHFactory = await ethers.getContractFactory("ERC7984NativeWrapper_Harness");
+    const eETH = (await eETHFactory.deploy(
+      wETH.target,
+      "ERC7984 Wrapped ETH",
+      "eETH",
+      "https://example.com/eeth.json",
+    )) as ERC7984NativeWrapper_Harness;
+    await eETH.waitForDeployment();
+
+    return { wETH, eETH };
+  };
+
+  async function setupFixture() {
+    const [owner, bob, alice, eve] = await ethers.getSigners();
+    const { wETH, eETH } = await deployContracts();
+
+    const ownerClient = await hre.cofhe.createClientWithBatteries(owner);
+    const bobClient = await hre.cofhe.createClientWithBatteries(bob);
+    const aliceClient = await hre.cofhe.createClientWithBatteries(alice);
+    const eveClient = await hre.cofhe.createClientWithBatteries(eve);
+
+    return { ownerClient, bobClient, aliceClient, eveClient, owner, bob, alice, eve, wETH, eETH };
+  }
+
+  // wETH has 18 decimals → rate = 1e12, confidential decimals = 6
+  const conversionRate = 1_000_000_000_000n; // 1e12
+
+  describe("initialization", function () {
+    it("should be constructed correctly", async function () {
+      const { wETH, eETH } = await setupFixture();
+
+      expect(await eETH.name()).to.equal("ERC7984 Wrapped ETH");
+      expect(await eETH.symbol()).to.equal("eETH");
+      expect(await eETH.decimals()).to.equal(6);
+      expect(await eETH.contractURI()).to.equal("https://example.com/eeth.json");
+      expect(await eETH.weth()).to.equal(wETH.target);
+      expect(await eETH.rate()).to.equal(conversionRate);
+      expect(await eETH.maxTotalSupply()).to.equal(BigInt("18446744073709551615"));
+      expect(await eETH.inferredTotalSupply()).to.equal(0n);
+    });
+
+    it("should support expected interfaces", async function () {
+      const { eETH } = await setupFixture();
+
+      // ERC165
+      expect(await eETH.supportsInterface("0x01ffc9a7")).to.equal(true);
+      // Random unsupported
+      expect(await eETH.supportsInterface("0xdeadbeef")).to.equal(false);
+    });
+
+    it("should allow symbol update", async function () {
+      const { eETH } = await setupFixture();
+
+      await expect(eETH.updateSymbol("encETH")).to.emit(eETH, "SymbolUpdated").withArgs("encETH");
+      expect(await eETH.symbol()).to.equal("encETH");
+    });
+  });
+
+  describe("shieldWrappedNative (WETH → ERC7984)", function () {
+    it("should shield WETH successfully", async function () {
+      const { eETH, bob, wETH } = await setupFixture();
+
+      const mintValue = ethers.parseEther("10");
+      const shieldValue = ethers.parseEther("1");
+      const confidentialValue = shieldValue / conversionRate; // 1e6
+
+      await wETH.connect(bob).deposit({ value: mintValue });
+      await wETH.connect(bob).approve(eETH.target, mintValue);
+
+      await prepExpectERC7984BalancesChange(eETH, bob.address);
+
+      await expect(eETH.connect(bob).shieldWrappedNative(bob, shieldValue)).to.emit(eETH, "ShieldedNative");
+
+      await expectERC7984BalancesChange(eETH, bob.address, confidentialValue);
+      await hre.cofhe.mocks.expectPlaintext(await eETH.confidentialTotalSupply(), confidentialValue);
+    });
+
+    it("should shield WETH to a different recipient", async function () {
+      const { eETH, bob, alice, wETH } = await setupFixture();
+
+      const shieldValue = ethers.parseEther("1");
+      const confidentialValue = shieldValue / conversionRate;
+
+      await wETH.connect(bob).deposit({ value: shieldValue });
+      await wETH.connect(bob).approve(eETH.target, shieldValue);
+
+      await prepExpectERC7984BalancesChange(eETH, alice.address);
+
+      await eETH.connect(bob).shieldWrappedNative(alice, shieldValue);
+
+      await expectERC7984BalancesChange(eETH, alice.address, confidentialValue);
+    });
+
+    it("should truncate amount to rate multiple", async function () {
+      const { eETH, bob, wETH } = await setupFixture();
+
+      const shieldValue = ethers.parseEther("1") + (conversionRate - 1n);
+      const alignedValue = ethers.parseEther("1");
+      const confidentialValue = alignedValue / conversionRate;
+
+      await wETH.connect(bob).deposit({ value: shieldValue });
+      await wETH.connect(bob).approve(eETH.target, shieldValue);
+
+      await prepExpectERC7984BalancesChange(eETH, bob.address);
+
+      await eETH.connect(bob).shieldWrappedNative(bob, shieldValue);
+
+      await expectERC7984BalancesChange(eETH, bob.address, confidentialValue);
+    });
+
+    it("should revert when amount too small for confidential precision", async function () {
+      const { eETH, bob, wETH } = await setupFixture();
+
+      const dust = conversionRate - 1n;
+      await wETH.connect(bob).deposit({ value: dust });
+      await wETH.connect(bob).approve(eETH.target, dust);
+
+      await expect(
+        eETH.connect(bob).shieldWrappedNative(bob, dust),
+      ).to.be.revertedWithCustomError(eETH, "AmountTooSmallForConfidentialPrecision");
+    });
+
+    it("should default to msg.sender when to is zero address", async function () {
+      const { eETH, bob, wETH } = await setupFixture();
+
+      const shieldValue = ethers.parseEther("1");
+      const confidentialValue = shieldValue / conversionRate;
+
+      await wETH.connect(bob).deposit({ value: shieldValue });
+      await wETH.connect(bob).approve(eETH.target, shieldValue);
+
+      await prepExpectERC7984BalancesChange(eETH, bob.address);
+
+      await eETH.connect(bob).shieldWrappedNative(ZeroAddress, shieldValue);
+
+      await expectERC7984BalancesChange(eETH, bob.address, confidentialValue);
+    });
+  });
+
+  describe("shieldNative (ETH → ERC7984)", function () {
+    it("should shield native ETH successfully", async function () {
+      const { eETH, bob } = await setupFixture();
+
+      const shieldValue = ethers.parseEther("1");
+      const confidentialValue = shieldValue / conversionRate;
+
+      await prepExpectERC7984BalancesChange(eETH, bob.address);
+
+      await expect(eETH.connect(bob).shieldNative(bob, { value: shieldValue })).to.emit(eETH, "ShieldedNative");
+
+      await expectERC7984BalancesChange(eETH, bob.address, confidentialValue);
+      await hre.cofhe.mocks.expectPlaintext(await eETH.confidentialTotalSupply(), confidentialValue);
+    });
+
+    it("should refund dust below conversion rate", async function () {
+      const { eETH, bob } = await setupFixture();
+
+      const alignedValue = ethers.parseEther("1");
+      const dust = conversionRate - 1n;
+      const totalSent = alignedValue + dust;
+      const confidentialValue = alignedValue / conversionRate;
+
+      await prepExpectERC7984BalancesChange(eETH, bob.address);
+
+      await eETH.connect(bob).shieldNative(bob, { value: totalSent });
+
+      await expectERC7984BalancesChange(eETH, bob.address, confidentialValue);
+    });
+
+    it("should revert when amount too small for confidential precision", async function () {
+      const { eETH, bob } = await setupFixture();
+
+      const dust = conversionRate - 1n;
+
+      await expect(
+        eETH.connect(bob).shieldNative(bob, { value: dust }),
+      ).to.be.revertedWithCustomError(eETH, "AmountTooSmallForConfidentialPrecision");
+    });
+
+    it("should default to msg.sender when to is zero address", async function () {
+      const { eETH, bob } = await setupFixture();
+
+      const shieldValue = ethers.parseEther("1");
+      const confidentialValue = shieldValue / conversionRate;
+
+      await prepExpectERC7984BalancesChange(eETH, bob.address);
+
+      await eETH.connect(bob).shieldNative(ZeroAddress, { value: shieldValue });
+
+      await expectERC7984BalancesChange(eETH, bob.address, confidentialValue);
+    });
+  });
+
+  describe("unshield & claimUnshielded (ERC7984 → ETH)", function () {
+    async function setupShieldedFixture() {
+      const fixture = await setupFixture();
+      const { eETH, bob } = fixture;
+
+      const mintValue = ethers.parseEther("10");
+      await eETH.connect(bob).shieldNative(bob, { value: mintValue });
+
+      return fixture;
+    }
+
+    it("should complete unshield and claim flow", async function () {
+      const { eETH, bob, alice, bobClient } = await setupShieldedFixture();
+
+      const unshieldConfidentialValue = 1_000_000n;
+      const unshieldNativeValue = unshieldConfidentialValue * conversionRate; // 1e18
+
+      const [encAmount] = await bobClient.encryptInputs([Encryptable.uint64(unshieldConfidentialValue)]).execute();
+
+      await prepExpectERC7984BalancesChange(eETH, bob.address);
+
+      const tx = await eETH
+        .connect(bob)
+        ["unshield(address,address,(uint256,uint8,uint8,bytes))"](bob.address, alice.address, encAmount);
+
+      await expect(tx).to.emit(eETH, "Unshielded");
+      await expectERC7984BalancesChange(eETH, bob.address, -1n * unshieldConfidentialValue);
+
+      const unshieldRequestId = await getUnshieldRequestId(tx, eETH);
+
+      expect(await eETH.unshieldRequester(unshieldRequestId)).to.equal(alice.address);
+
+      // Time travel past decryption delay
+      await hre.network.provider.send("evm_increaseTime", [11]);
+      await hre.network.provider.send("evm_mine");
+
+      const decryption = await bobClient.decryptForTx(unshieldRequestId).withoutPermit().execute();
+
+      const aliceBalanceBefore = await ethers.provider.getBalance(alice.address);
+
+      await expect(
+        eETH.connect(bob).claimUnshielded(unshieldRequestId, decryption.decryptedValue, decryption.signature),
+      ).to.emit(eETH, "ClaimedUnshielded");
+
+      const aliceBalanceAfter = await ethers.provider.getBalance(alice.address);
+      expect(aliceBalanceAfter - aliceBalanceBefore).to.equal(unshieldNativeValue);
+
+      // Request is cleared
+      expect(await eETH.unshieldRequester(unshieldRequestId)).to.equal(ZeroAddress);
+    });
+
+    it("should allow unshield by operator", async function () {
+      const { eETH, bob, alice, aliceClient } = await setupShieldedFixture();
+
+      const unshieldConfidentialValue = 1_000_000n;
+      const unshieldNativeValue = unshieldConfidentialValue * conversionRate;
+
+      const timestamp = (await ethers.provider.getBlock("latest"))!.timestamp + 100;
+      await eETH.connect(bob).setOperator(alice.address, timestamp);
+
+      const [encAmount] = await aliceClient.encryptInputs([Encryptable.uint64(unshieldConfidentialValue)]).execute();
+
+      await prepExpectERC7984BalancesChange(eETH, bob.address);
+
+      const tx = await eETH
+        .connect(alice)
+        ["unshield(address,address,(uint256,uint8,uint8,bytes))"](bob.address, alice.address, encAmount);
+
+      await expect(tx).to.emit(eETH, "Unshielded");
+      await expectERC7984BalancesChange(eETH, bob.address, -1n * unshieldConfidentialValue);
+
+      const unshieldRequestId = await getUnshieldRequestId(tx, eETH);
+
+      await hre.network.provider.send("evm_increaseTime", [11]);
+      await hre.network.provider.send("evm_mine");
+
+      const decryption = await aliceClient.decryptForTx(unshieldRequestId).withoutPermit().execute();
+
+      const aliceBalanceBefore = await ethers.provider.getBalance(alice.address);
+
+      await eETH.connect(bob).claimUnshielded(unshieldRequestId, decryption.decryptedValue, decryption.signature);
+
+      const aliceBalanceAfter = await ethers.provider.getBalance(alice.address);
+      expect(aliceBalanceAfter - aliceBalanceBefore).to.equal(unshieldNativeValue);
+    });
+  });
+
+  describe("unshield reverts", function () {
+    it("should revert on zero address receiver", async function () {
+      const { eETH, bob, bobClient } = await setupFixture();
+
+      await eETH.connect(bob).shieldNative(bob, { value: ethers.parseEther("10") });
+
+      const [encAmount] = await bobClient.encryptInputs([Encryptable.uint64(1_000_000n)]).execute();
+
+      await expect(
+        eETH
+          .connect(bob)
+          ["unshield(address,address,(uint256,uint8,uint8,bytes))"](bob.address, ZeroAddress, encAmount),
+      ).to.be.revertedWithCustomError(eETH, "ERC7984InvalidReceiver");
+    });
+
+    it("should revert when caller is not operator", async function () {
+      const { eETH, bob, alice, aliceClient } = await setupFixture();
+
+      await eETH.connect(bob).shieldNative(bob, { value: ethers.parseEther("10") });
+
+      const [encAmount] = await aliceClient.encryptInputs([Encryptable.uint64(1_000_000n)]).execute();
+
+      await expect(
+        eETH
+          .connect(alice)
+          ["unshield(address,address,(uint256,uint8,uint8,bytes))"](bob.address, alice.address, encAmount),
+      ).to.be.revertedWithCustomError(eETH, "ERC7984UnauthorizedSpender");
+    });
+  });
+
+  describe("claimUnshielded reverts", function () {
+    it("should revert on invalid request id", async function () {
+      const { eETH } = await setupFixture();
+
+      await expect(
+        eETH.claimUnshielded(ethers.ZeroHash, 0n, new Uint8Array(0)),
+      ).to.be.revertedWithCustomError(eETH, "InvalidUnshieldRequest");
+    });
+  });
+});

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -61,6 +61,38 @@ export const expectFHERC20BalancesChange = async (
   );
 };
 
+// ERC7984 BALANCES
+
+const erc7984EncBalances = new Map<string, bigint>();
+
+export const prepExpectERC7984BalancesChange = async (
+  token: { confidentialBalanceOf: (account: string) => Promise<string> },
+  account: string,
+) => {
+  const encBalanceHash = await token.confidentialBalanceOf(account);
+  const encBalance = await hre.cofhe.mocks.getPlaintext(encBalanceHash);
+  erc7984EncBalances.set(account, encBalance);
+};
+
+export const expectERC7984BalancesChange = async (
+  token: { confidentialBalanceOf: (account: string) => Promise<string>; symbol: () => Promise<string> },
+  account: string,
+  expectedEncChange: bigint,
+) => {
+  const symbol = await token.symbol();
+
+  const currEncBalanceHash = await token.confidentialBalanceOf(account);
+  const currEncBalance = await hre.cofhe.mocks.getPlaintext(currEncBalanceHash);
+  const prevEncBalance = erc7984EncBalances.get(account)!;
+  const encChange = currEncBalance - prevEncBalance;
+  expect(encChange).to.equal(
+    expectedEncChange,
+    `${symbol} (ERC7984) encrypted balance change for ${account} is incorrect. Expected: ${expectedEncChange}, received: ${encChange}`,
+  );
+};
+
+// ERC20 BALANCES
+
 const erc20Balances = new Map<string, bigint>();
 
 export const prepExpectERC20BalancesChange = async (token: ERC20, account: string) => {


### PR DESCRIPTION
CoFHE implementation of the ERC7984 standard

### Contracts:

- `ERC7984` — base confidential token (`IERC7984`, `Context`, `ERC165`)
- `ERC7984ERC20Wrapper` — abstract extension for wrapping ERC-20 tokens
- `ERC7984NativeWrapper` — abstract extension for wrapping native tokens (ETH)
- `ERC7984WrapperClaimHelper` — abstract extension for unshield claim lifecycle
- `ERC7984Utils` — library for `transferAndCall` receiver callbacks
- `FHESafeMath` — library for safe encrypted arithmetic

### Differences:

Encrypted Type: `euint128` → `euint64` (balances, transfers, amounts, events)

Name changes:
| FHERC20 | ERC7984 |
|---|---|
| `encTransfer(to, value)` | `confidentialTransfer(to, amount)` |
| `encTransferFrom(from, to, value, permit)` | `confidentialTransferFrom(from, to, amount)` |
| `encBalanceOf(account)` | `confidentialBalanceOf(account)` |
| `encTotalSupply()` | `confidentialTotalSupply()` |
| `encrypt(to, value)` | `shield(to, amount)` |
| `decrypt(to, value)` | `unshield(from, to, amount)` |
| `claimDecrypted(ctHash)` | `claimUnshielded(ctHash, amount, proof)` |
| `isFherc20()` | `supportsInterface(IERC7984)` |

Authorization: EIP-712 Permits → Operators

Claim Flow: Tx Sender → Decryption Proofs

Decimals: The FHERC20 Wrappers used full decimal precision, ERC7984 wrappers cap decimals at 6 (uses `rate()`). Dust on shield is refunded to caller.

Indicators: Replaced FHERC20 indicated balances (0.0000–0.9999 range, midpoint start at 0.5000, wrapping at boundaries) with new indicated balances (7984 prefix + indicator tick, ie 7984.0001 is the amount transferred). 

Unshielding: FHERC20's `decrypt(to, value)` always burned from `msg.sender`. ERC7984's `unshield(from, to, amount)` accepts a `from` parameter (msg.sender must be `from` or operator for `from`).