### PR TITLE
Extract FHERC20Errors

### DIFF
--- a/.changeset/extract-fherc20-errors.md
+++ b/.changeset/extract-fherc20-errors.md
@@ -1,0 +1,5 @@
+---
+"fhenix-confidential-contracts": patch
+---
+
+Extract shared FHERC20 errors to file-scope definitions in `FHERC20Errors.sol` to eliminate duplicate ABI entries across `FHERC20`, `FHERC20Upgradeable`, and `FHERC20Utils`.

--- a/contracts/FHERC20/FHERC20.sol
+++ b/contracts/FHERC20/FHERC20.sol
@@ -10,6 +10,15 @@ import { ERC165 } from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import { IFHERC20, IERC7984 } from "../interfaces/IFHERC20.sol";
 import { FHESafeMath } from "../utils/FHESafeMath.sol";
 import { FHERC20Utils } from "./utils/FHERC20Utils.sol";
+import {
+    FHERC20InvalidReceiver,
+    FHERC20InvalidSender,
+    FHERC20UnauthorizedSpender,
+    FHERC20ZeroBalance,
+    FHERC20UnauthorizedUseOfEncryptedAmount,
+    FHERC20UnauthorizedCaller,
+    FHERC20IncompatibleFunction
+} from "./utils/FHERC20Errors.sol";
 
 /**
  * @dev Reference implementation for {IFHERC20}.
@@ -52,31 +61,6 @@ abstract contract FHERC20 is IFHERC20, Context, ERC165 {
 
     /// @dev Emitted when an encrypted amount `encryptedAmount` is requested for disclosure by `requester`.
     event AmountDiscloseRequested(euint64 indexed encryptedAmount, address indexed requester);
-
-    /// @dev The given receiver `receiver` is invalid for transfers.
-    error FHERC20InvalidReceiver(address receiver);
-
-    /// @dev The given sender `sender` is invalid for transfers.
-    error FHERC20InvalidSender(address sender);
-
-    /// @dev The given holder `holder` is not authorized to spend on behalf of `spender`.
-    error FHERC20UnauthorizedSpender(address holder, address spender);
-
-    /// @dev The holder `holder` is trying to send tokens but has a balance of 0.
-    error FHERC20ZeroBalance(address holder);
-
-    /**
-     * @dev The caller `user` does not have access to the encrypted amount `amount`.
-     *
-     * NOTE: Try using the equivalent transfer function with an input proof.
-     */
-    error FHERC20UnauthorizedUseOfEncryptedAmount(euint64 amount, address user);
-
-    /// @dev The given caller `caller` is not authorized for the current operation.
-    error FHERC20UnauthorizedCaller(address caller);
-
-    /// @dev Reverts when a cleartext ERC-20 function is called on a confidential token.
-    error FHERC20IncompatibleFunction();
 
     constructor(string memory name_, string memory symbol_, uint8 decimals_, string memory contractURI_) {
         _name = name_;

--- a/contracts/FHERC20/FHERC20Upgradeable.sol
+++ b/contracts/FHERC20/FHERC20Upgradeable.sol
@@ -11,6 +11,15 @@ import { IERC165 } from "@openzeppelin/contracts/interfaces/IERC165.sol";
 import { IFHERC20, IERC7984 } from "../interfaces/IFHERC20.sol";
 import { FHESafeMath } from "../utils/FHESafeMath.sol";
 import { FHERC20Utils } from "./utils/FHERC20Utils.sol";
+import {
+    FHERC20InvalidReceiver,
+    FHERC20InvalidSender,
+    FHERC20UnauthorizedSpender,
+    FHERC20ZeroBalance,
+    FHERC20UnauthorizedUseOfEncryptedAmount,
+    FHERC20UnauthorizedCaller,
+    FHERC20IncompatibleFunction
+} from "./utils/FHERC20Errors.sol";
 
 /**
  * @dev Upgradeable implementation of {IFHERC20}.
@@ -58,31 +67,6 @@ abstract contract FHERC20Upgradeable is Initializable, IFHERC20, ContextUpgradea
 
     /// @dev Emitted when an encrypted amount `encryptedAmount` is requested for disclosure by `requester`.
     event AmountDiscloseRequested(euint64 indexed encryptedAmount, address indexed requester);
-
-    /// @dev The given receiver `receiver` is invalid for transfers.
-    error FHERC20InvalidReceiver(address receiver);
-
-    /// @dev The given sender `sender` is invalid for transfers.
-    error FHERC20InvalidSender(address sender);
-
-    /// @dev The given holder `holder` is not authorized to spend on behalf of `spender`.
-    error FHERC20UnauthorizedSpender(address holder, address spender);
-
-    /// @dev The holder `holder` is trying to send tokens but has a balance of 0.
-    error FHERC20ZeroBalance(address holder);
-
-    /**
-     * @dev The caller `user` does not have access to the encrypted amount `amount`.
-     *
-     * NOTE: Try using the equivalent transfer function with an input proof.
-     */
-    error FHERC20UnauthorizedUseOfEncryptedAmount(euint64 amount, address user);
-
-    /// @dev The given caller `caller` is not authorized for the current operation.
-    error FHERC20UnauthorizedCaller(address caller);
-
-    /// @dev Reverts when a cleartext ERC-20 function is called on a confidential token.
-    error FHERC20IncompatibleFunction();
 
     /**
      * @dev Sets the values for {name}, {symbol}, {decimals}, and {contractURI}.

--- a/contracts/FHERC20/extensions/FHERC20ERC20Wrapper.sol
+++ b/contracts/FHERC20/extensions/FHERC20ERC20Wrapper.sol
@@ -12,6 +12,7 @@ import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { IFHERC20ERC20Wrapper } from "../../interfaces/IFHERC20ERC20Wrapper.sol";
 import { FHERC20 } from "../FHERC20.sol";
 import { FHERC20WrapperClaimHelper } from "../utils/FHERC20WrapperClaimHelper.sol";
+import { FHERC20InvalidReceiver, FHERC20UnauthorizedSpender, FHERC20UnauthorizedCaller } from "../utils/FHERC20Errors.sol";
 
 /**
  * @dev A wrapper contract built on top of {FHERC20} that allows shielding an `ERC20` token

--- a/contracts/FHERC20/extensions/FHERC20ERC20WrapperUpgradeable.sol
+++ b/contracts/FHERC20/extensions/FHERC20ERC20WrapperUpgradeable.sol
@@ -11,6 +11,7 @@ import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { IFHERC20ERC20Wrapper } from "../../interfaces/IFHERC20ERC20Wrapper.sol";
 import { FHERC20Upgradeable } from "../FHERC20Upgradeable.sol";
 import { FHERC20WrapperClaimHelperUpgradeable } from "../utils/FHERC20WrapperClaimHelperUpgradeable.sol";
+import { FHERC20InvalidReceiver, FHERC20UnauthorizedSpender, FHERC20UnauthorizedCaller } from "../utils/FHERC20Errors.sol";
 
 /**
  * @dev Upgradeable wrapper that shields a standard ERC-20 token into a confidential {FHERC20} token.

--- a/contracts/FHERC20/extensions/FHERC20NativeWrapper.sol
+++ b/contracts/FHERC20/extensions/FHERC20NativeWrapper.sol
@@ -10,6 +10,7 @@ import { IFHERC20NativeWrapper } from "../../interfaces/IFHERC20NativeWrapper.so
 import { IWETH } from "../../interfaces/IWETH.sol";
 import { FHERC20 } from "../FHERC20.sol";
 import { FHERC20WrapperClaimHelper } from "../utils/FHERC20WrapperClaimHelper.sol";
+import { FHERC20InvalidReceiver, FHERC20UnauthorizedSpender } from "../utils/FHERC20Errors.sol";
 
 /**
  * @dev A wrapper contract built on top of {FHERC20} that shields a chain's native token

--- a/contracts/FHERC20/extensions/FHERC20NativeWrapperUpgradeable.sol
+++ b/contracts/FHERC20/extensions/FHERC20NativeWrapperUpgradeable.sol
@@ -9,6 +9,7 @@ import { IFHERC20NativeWrapper } from "../../interfaces/IFHERC20NativeWrapper.so
 import { IWETH } from "../../interfaces/IWETH.sol";
 import { FHERC20Upgradeable } from "../FHERC20Upgradeable.sol";
 import { FHERC20WrapperClaimHelperUpgradeable } from "../utils/FHERC20WrapperClaimHelperUpgradeable.sol";
+import { FHERC20InvalidReceiver, FHERC20UnauthorizedSpender } from "../utils/FHERC20Errors.sol";
 
 /**
  * @dev Upgradeable wrapper that shields a chain's native token (e.g. ETH) into a confidential {FHERC20} token.

--- a/contracts/FHERC20/utils/FHERC20Errors.sol
+++ b/contracts/FHERC20/utils/FHERC20Errors.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { euint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+
+/// @dev The given receiver `receiver` is invalid for transfers.
+error FHERC20InvalidReceiver(address receiver);
+
+/// @dev The given sender `sender` is invalid for transfers.
+error FHERC20InvalidSender(address sender);
+
+/// @dev The given holder `holder` is not authorized to spend on behalf of `spender`.
+error FHERC20UnauthorizedSpender(address holder, address spender);
+
+/// @dev The holder `holder` is trying to send tokens but has a balance of 0.
+error FHERC20ZeroBalance(address holder);
+
+/**
+ * @dev The caller `user` does not have access to the encrypted amount `amount`.
+ *
+ * NOTE: Try using the equivalent transfer function with an input proof.
+ */
+error FHERC20UnauthorizedUseOfEncryptedAmount(euint64 amount, address user);
+
+/// @dev The given caller `caller` is not authorized for the current operation.
+error FHERC20UnauthorizedCaller(address caller);
+
+/// @dev Reverts when a cleartext ERC-20 function is called on a confidential token.
+error FHERC20IncompatibleFunction();

--- a/contracts/FHERC20/utils/FHERC20Utils.sol
+++ b/contracts/FHERC20/utils/FHERC20Utils.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.25;
 import { FHE, ebool, euint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
 
 import { IERC7984Receiver } from "../../interfaces/IERC7984Receiver.sol";
-import { FHERC20 } from "../FHERC20.sol";
+import { FHERC20InvalidReceiver } from "./FHERC20Errors.sol";
 
 /// @dev Library that provides common {FHERC20} utility functions.
 library FHERC20Utils {
@@ -32,7 +32,7 @@ library FHERC20Utils {
                 return retval;
             } catch (bytes memory reason) {
                 if (reason.length == 0) {
-                    revert FHERC20.FHERC20InvalidReceiver(to);
+                    revert FHERC20InvalidReceiver(to);
                 } else {
                     assembly ("memory-safe") {
                         revert(add(32, reason), mload(reason))


### PR DESCRIPTION
Pull errors out into reusable file to prevent compilation logs like this:
```
duplicate definition - FHERC20InvalidReceiver(address)
duplicate definition - FHERC20InvalidReceiver(address)
duplicate definition - FHERC20InvalidReceiver(address)
duplicate definition - FHERC20InvalidReceiver(address)
duplicate definition - FHERC20InvalidReceiver(address)
duplicate definition - FHERC20InvalidReceiver(address)
duplicate definition - FHERC20InvalidReceiver(address)
```

This was caused by FHERC20Utils.sol importing `FHERC20.FHERC20InvalidReceiver`. When `FHERC20Utils.sol` was imported from `FHERC20Upgradeable.sol` (which also included its own `FHERC20InvalidReceiver` error), the errors would clash and throw.