### PR TITLE
Add unshield with encrypted euint64 input

### DIFF
--- a/.changeset/forty-deserts-sell.md
+++ b/.changeset/forty-deserts-sell.md
@@ -1,0 +1,5 @@
+---
+"fhenix-confidential-contracts": patch
+---
+
+Add new 'unshield' overload function that accepts an encrypted amount.

--- a/contracts/FHERC20/extensions/FHERC20ERC20Wrapper.sol
+++ b/contracts/FHERC20/extensions/FHERC20ERC20Wrapper.sol
@@ -12,7 +12,7 @@ import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { IFHERC20ERC20Wrapper } from "../../interfaces/IFHERC20ERC20Wrapper.sol";
 import { FHERC20 } from "../FHERC20.sol";
 import { FHERC20WrapperClaimHelper } from "../utils/FHERC20WrapperClaimHelper.sol";
-import { FHERC20InvalidReceiver, FHERC20UnauthorizedSpender, FHERC20UnauthorizedCaller } from "../utils/FHERC20Errors.sol";
+import { FHERC20InvalidReceiver, FHERC20UnauthorizedSpender, FHERC20UnauthorizedCaller, FHERC20UnauthorizedUseOfEncryptedAmount } from "../utils/FHERC20Errors.sol";
 
 /**
  * @dev A wrapper contract built on top of {FHERC20} that allows shielding an `ERC20` token
@@ -88,16 +88,19 @@ abstract contract FHERC20ERC20Wrapper is FHERC20, IFHERC20ERC20Wrapper, IERC1363
      * Returns the encrypted amount that was burned (used as the claim's cipher-text handle).
      */
     function unshield(address from, address to, uint64 amount) public virtual returns (euint64) {
-        if (to == address(0)) revert FHERC20InvalidReceiver(to);
-        if (from != msg.sender && !isOperator(from, msg.sender)) revert FHERC20UnauthorizedSpender(from, msg.sender);
+        return _unshield(from, to, FHE.asEuint64(amount), amount);
+    }
 
-        euint64 unshieldAmount_ = _burn(from, FHE.asEuint64(amount));
-        FHE.allowPublic(unshieldAmount_);
-
-        _createClaim(to, amount, unshieldAmount_);
-
-        emit Unshielded(to, unshieldAmount_);
-        return unshieldAmount_;
+    /**
+     * @dev Initiates an unshield of an encrypted `amount` from `from`, creating a pending
+     * unshield request for `to`. The caller must have ACL access to `amount` and must be
+     * `from` or an operator for `from`.
+     *
+     * Returns the encrypted amount that was burned.
+     */
+    function unshield(address from, address to, euint64 amount) public virtual returns (euint64) {
+        if (!FHE.isAllowed(amount, msg.sender)) revert FHERC20UnauthorizedUseOfEncryptedAmount(amount, msg.sender);
+        return _unshield(from, to, amount, 0);
     }
 
     /**
@@ -185,6 +188,20 @@ abstract contract FHERC20ERC20Wrapper is FHERC20, IFHERC20ERC20Wrapper, IERC1363
             _checkConfidentialTotalSupply();
         }
         return super._update(from, to, amount);
+    }
+
+    /// @dev Shared internal logic for both unshield overloads.
+    function _unshield(address from, address to, euint64 amount, uint64 requestedAmount) internal virtual returns (euint64) {
+        if (to == address(0)) revert FHERC20InvalidReceiver(to);
+        if (from != msg.sender && !isOperator(from, msg.sender)) revert FHERC20UnauthorizedSpender(from, msg.sender);
+
+        euint64 unshieldAmount_ = _burn(from, amount);
+        FHE.allowPublic(unshieldAmount_);
+
+        _createClaim(to, requestedAmount, unshieldAmount_);
+
+        emit Unshielded(to, unshieldAmount_);
+        return unshieldAmount_;
     }
 
     /**

--- a/contracts/FHERC20/extensions/FHERC20ERC20WrapperUpgradeable.sol
+++ b/contracts/FHERC20/extensions/FHERC20ERC20WrapperUpgradeable.sol
@@ -11,7 +11,7 @@ import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { IFHERC20ERC20Wrapper } from "../../interfaces/IFHERC20ERC20Wrapper.sol";
 import { FHERC20Upgradeable } from "../FHERC20Upgradeable.sol";
 import { FHERC20WrapperClaimHelperUpgradeable } from "../utils/FHERC20WrapperClaimHelperUpgradeable.sol";
-import { FHERC20InvalidReceiver, FHERC20UnauthorizedSpender, FHERC20UnauthorizedCaller } from "../utils/FHERC20Errors.sol";
+import { FHERC20InvalidReceiver, FHERC20UnauthorizedSpender, FHERC20UnauthorizedCaller, FHERC20UnauthorizedUseOfEncryptedAmount } from "../utils/FHERC20Errors.sol";
 
 /**
  * @dev Upgradeable wrapper that shields a standard ERC-20 token into a confidential {FHERC20} token.
@@ -90,17 +90,26 @@ abstract contract FHERC20ERC20WrapperUpgradeable is
         return shieldedAmountSent;
     }
 
+    /**
+     * @dev Initiates an unshield of `amount` confidential tokens from `from`, creating a pending
+     * claim for `to`. The caller must be `from` or an operator for `from`.
+     *
+     * Returns the encrypted amount that was burned (used as the claim's cipher-text handle).
+     */
     function unshield(address from, address to, uint64 amount) public virtual returns (euint64) {
-        if (to == address(0)) revert FHERC20InvalidReceiver(to);
-        if (from != msg.sender && !isOperator(from, msg.sender)) revert FHERC20UnauthorizedSpender(from, msg.sender);
+        return _unshield(from, to, FHE.asEuint64(amount), amount);
+    }
 
-        euint64 unshieldAmount_ = _burn(from, FHE.asEuint64(amount));
-        FHE.allowPublic(unshieldAmount_);
-
-        _createClaim(to, amount, unshieldAmount_);
-
-        emit Unshielded(to, unshieldAmount_);
-        return unshieldAmount_;
+    /**
+     * @dev Initiates an unshield of an encrypted `amount` from `from`, creating a pending
+     * unshield request for `to`. The caller must have ACL access to `amount` and must be
+     * `from` or an operator for `from`.
+     *
+     * Returns the encrypted amount that was burned.
+     */
+    function unshield(address from, address to, euint64 amount) public virtual returns (euint64) {
+        if (!FHE.isAllowed(amount, msg.sender)) revert FHERC20UnauthorizedUseOfEncryptedAmount(amount, msg.sender);
+        return _unshield(from, to, amount, 0);
     }
 
     function claimUnshielded(bytes32 ctHash, uint64 decryptedAmount, bytes memory decryptionProof) public virtual {
@@ -165,6 +174,20 @@ abstract contract FHERC20ERC20WrapperUpgradeable is
             _checkConfidentialTotalSupply();
         }
         return super._update(from, to, amount);
+    }
+
+    /// @dev Shared internal logic for both unshield overloads.
+    function _unshield(address from, address to, euint64 amount, uint64 requestedAmount) internal virtual returns (euint64) {
+        if (to == address(0)) revert FHERC20InvalidReceiver(to);
+        if (from != msg.sender && !isOperator(from, msg.sender)) revert FHERC20UnauthorizedSpender(from, msg.sender);
+
+        euint64 unshieldAmount_ = _burn(from, amount);
+        FHE.allowPublic(unshieldAmount_);
+
+        _createClaim(to, requestedAmount, unshieldAmount_);
+
+        emit Unshielded(to, unshieldAmount_);
+        return unshieldAmount_;
     }
 
     function _fallbackUnderlyingDecimals() internal pure virtual returns (uint8) {

--- a/contracts/FHERC20/extensions/FHERC20NativeWrapper.sol
+++ b/contracts/FHERC20/extensions/FHERC20NativeWrapper.sol
@@ -10,7 +10,7 @@ import { IFHERC20NativeWrapper } from "../../interfaces/IFHERC20NativeWrapper.so
 import { IWETH } from "../../interfaces/IWETH.sol";
 import { FHERC20 } from "../FHERC20.sol";
 import { FHERC20WrapperClaimHelper } from "../utils/FHERC20WrapperClaimHelper.sol";
-import { FHERC20InvalidReceiver, FHERC20UnauthorizedSpender } from "../utils/FHERC20Errors.sol";
+import { FHERC20InvalidReceiver, FHERC20UnauthorizedSpender, FHERC20UnauthorizedUseOfEncryptedAmount } from "../utils/FHERC20Errors.sol";
 
 /**
  * @dev A wrapper contract built on top of {FHERC20} that shields a chain's native token
@@ -100,16 +100,19 @@ abstract contract FHERC20NativeWrapper is FHERC20, IFHERC20NativeWrapper, FHERC2
      * Returns the encrypted amount that was burned (used as the claim's cipher-text handle).
      */
     function unshield(address from, address to, uint64 amount) public virtual returns (euint64) {
-        if (to == address(0)) revert FHERC20InvalidReceiver(to);
-        if (from != msg.sender && !isOperator(from, msg.sender)) revert FHERC20UnauthorizedSpender(from, msg.sender);
+        return _unshield(from, to, FHE.asEuint64(amount), amount);
+    }
 
-        euint64 unshieldAmount_ = _burn(from, FHE.asEuint64(amount));
-        FHE.allowPublic(unshieldAmount_);
-
-        _createClaim(to, amount, unshieldAmount_);
-
-        emit Unshielded(to, unshieldAmount_);
-        return unshieldAmount_;
+    /**
+     * @dev Initiates an unshield of an encrypted `amount` from `from`, creating a pending
+     * unshield request for `to`. The caller must have ACL access to `amount` and must be
+     * `from` or an operator for `from`.
+     *
+     * Returns the encrypted amount that was burned.
+     */
+    function unshield(address from, address to, euint64 amount) public virtual returns (euint64) {
+        if (!FHE.isAllowed(amount, msg.sender)) revert FHERC20UnauthorizedUseOfEncryptedAmount(amount, msg.sender);
+        return _unshield(from, to, amount, 0);
     }
 
     /**
@@ -205,6 +208,20 @@ abstract contract FHERC20NativeWrapper is FHERC20, IFHERC20NativeWrapper, FHERC2
             _checkConfidentialTotalSupply();
         }
         return super._update(from, to, amount);
+    }
+
+    /// @dev Shared internal logic for both unshield overloads.
+    function _unshield(address from, address to, euint64 amount, uint64 requestedAmount) internal virtual returns (euint64) {
+        if (to == address(0)) revert FHERC20InvalidReceiver(to);
+        if (from != msg.sender && !isOperator(from, msg.sender)) revert FHERC20UnauthorizedSpender(from, msg.sender);
+
+        euint64 unshieldAmount_ = _burn(from, amount);
+        FHE.allowPublic(unshieldAmount_);
+
+        _createClaim(to, requestedAmount, unshieldAmount_);
+
+        emit Unshielded(to, unshieldAmount_);
+        return unshieldAmount_;
     }
 
     /// @dev Returns the maximum number that will be used for {decimals} by the wrapper.

--- a/contracts/FHERC20/extensions/FHERC20NativeWrapperUpgradeable.sol
+++ b/contracts/FHERC20/extensions/FHERC20NativeWrapperUpgradeable.sol
@@ -9,7 +9,7 @@ import { IFHERC20NativeWrapper } from "../../interfaces/IFHERC20NativeWrapper.so
 import { IWETH } from "../../interfaces/IWETH.sol";
 import { FHERC20Upgradeable } from "../FHERC20Upgradeable.sol";
 import { FHERC20WrapperClaimHelperUpgradeable } from "../utils/FHERC20WrapperClaimHelperUpgradeable.sol";
-import { FHERC20InvalidReceiver, FHERC20UnauthorizedSpender } from "../utils/FHERC20Errors.sol";
+import { FHERC20InvalidReceiver, FHERC20UnauthorizedSpender, FHERC20UnauthorizedUseOfEncryptedAmount } from "../utils/FHERC20Errors.sol";
 
 /**
  * @dev Upgradeable wrapper that shields a chain's native token (e.g. ETH) into a confidential {FHERC20} token.
@@ -109,17 +109,26 @@ abstract contract FHERC20NativeWrapperUpgradeable is
         return shieldedAmountSent;
     }
 
+    /**
+     * @dev Initiates an unshield of `amount` confidential tokens from `from`, creating a pending
+     * claim for `to`. The caller must be `from` or an operator for `from`.
+     *
+     * Returns the encrypted amount that was burned (used as the claim's cipher-text handle).
+     */
     function unshield(address from, address to, uint64 amount) public virtual returns (euint64) {
-        if (to == address(0)) revert FHERC20InvalidReceiver(to);
-        if (from != msg.sender && !isOperator(from, msg.sender)) revert FHERC20UnauthorizedSpender(from, msg.sender);
+        return _unshield(from, to, FHE.asEuint64(amount), amount);
+    }
 
-        euint64 unshieldAmount_ = _burn(from, FHE.asEuint64(amount));
-        FHE.allowPublic(unshieldAmount_);
-
-        _createClaim(to, amount, unshieldAmount_);
-
-        emit Unshielded(to, unshieldAmount_);
-        return unshieldAmount_;
+    /**
+     * @dev Initiates an unshield of an encrypted `amount` from `from`, creating a pending
+     * unshield request for `to`. The caller must have ACL access to `amount` and must be
+     * `from` or an operator for `from`.
+     *
+     * Returns the encrypted amount that was burned.
+     */
+    function unshield(address from, address to, euint64 amount) public virtual returns (euint64) {
+        if (!FHE.isAllowed(amount, msg.sender)) revert FHERC20UnauthorizedUseOfEncryptedAmount(amount, msg.sender);
+        return _unshield(from, to, amount, 0);
     }
 
     function claimUnshielded(bytes32 ctHash, uint64 decryptedAmount, bytes memory decryptionProof) public virtual {
@@ -187,6 +196,20 @@ abstract contract FHERC20NativeWrapperUpgradeable is
             _checkConfidentialTotalSupply();
         }
         return super._update(from, to, amount);
+    }
+
+    /// @dev Shared internal logic for both unshield overloads.
+    function _unshield(address from, address to, euint64 amount, uint64 requestedAmount) internal virtual returns (euint64) {
+        if (to == address(0)) revert FHERC20InvalidReceiver(to);
+        if (from != msg.sender && !isOperator(from, msg.sender)) revert FHERC20UnauthorizedSpender(from, msg.sender);
+
+        euint64 unshieldAmount_ = _burn(from, amount);
+        FHE.allowPublic(unshieldAmount_);
+
+        _createClaim(to, requestedAmount, unshieldAmount_);
+
+        emit Unshielded(to, unshieldAmount_);
+        return unshieldAmount_;
     }
 
     function _maxDecimals() internal pure virtual returns (uint8) {

--- a/contracts/interfaces/IFHERC20ERC20Wrapper.sol
+++ b/contracts/interfaces/IFHERC20ERC20Wrapper.sol
@@ -41,6 +41,15 @@ interface IFHERC20ERC20Wrapper {
     function unshield(address from, address to, uint64 amount) external returns (euint64);
 
     /**
+     * @dev Initiates an unshield of an encrypted `amount` from `from`, creating a pending
+     * unshield request for `to`. The caller must have ACL access to `amount` and must be
+     * `from` or an operator for `from`.
+     *
+     * Returns the encrypted amount that was burned.
+     */
+    function unshield(address from, address to, euint64 amount) external returns (euint64);
+
+    /**
      * @dev Claims a pending unshield request by verifying the decryption proof and transferring
      * `unshieldAmountCleartext * rate()` underlying tokens to the requester.
      */

--- a/contracts/interfaces/IFHERC20NativeWrapper.sol
+++ b/contracts/interfaces/IFHERC20NativeWrapper.sol
@@ -56,6 +56,15 @@ interface IFHERC20NativeWrapper {
     function unshield(address from, address to, uint64 amount) external returns (euint64);
 
     /**
+     * @dev Initiates an unshield of an encrypted `amount` from `from`, creating a pending
+     * unshield request for `to`. The caller must have ACL access to `amount` and must be
+     * `from` or an operator for `from`.
+     *
+     * Returns the encrypted amount that was burned.
+     */
+    function unshield(address from, address to, euint64 amount) external returns (euint64);
+
+    /**
      * @dev Claims a pending unshield request by verifying the decryption proof and transferring
      * `unshieldAmountCleartext * rate()` native tokens to the requester.
      */

--- a/test/FHERC20ERC20Wrapper.test.ts
+++ b/test/FHERC20ERC20Wrapper.test.ts
@@ -184,7 +184,7 @@ describe("FHERC20ERC20Wrapper", function () {
 
       await prepExpectFHERC20BalancesChange(eBTC, bob.address);
 
-      const tx = await eBTC.connect(bob).unshield(bob.address, alice.address, unshieldConfidentialValue);
+      const tx = await eBTC.connect(bob)["unshield(address,address,uint64)"](bob.address, alice.address, unshieldConfidentialValue);
 
       await expect(tx).to.emit(eBTC, "Unshielded");
       await expectFHERC20BalancesChange(eBTC, bob.address, -1n * unshieldConfidentialValue);
@@ -234,7 +234,7 @@ describe("FHERC20ERC20Wrapper", function () {
 
       await prepExpectFHERC20BalancesChange(eBTC, bob.address);
 
-      const tx = await eBTC.connect(alice).unshield(bob.address, alice.address, unshieldConfidentialValue);
+      const tx = await eBTC.connect(alice)["unshield(address,address,uint64)"](bob.address, alice.address, unshieldConfidentialValue);
 
       await expect(tx).to.emit(eBTC, "Unshielded");
       await expectFHERC20BalancesChange(eBTC, bob.address, -1n * unshieldConfidentialValue);
@@ -260,11 +260,11 @@ describe("FHERC20ERC20Wrapper", function () {
       const unshieldAmount2 = 300_000n;
 
       // Create first unshield
-      const tx1 = await eBTC.connect(bob).unshield(bob.address, alice.address, unshieldAmount1);
+      const tx1 = await eBTC.connect(bob)["unshield(address,address,uint64)"](bob.address, alice.address, unshieldAmount1);
       const requestId1 = await getUnshieldRequestId(tx1, eBTC);
 
       // Create second unshield
-      const tx2 = await eBTC.connect(bob).unshield(bob.address, alice.address, unshieldAmount2);
+      const tx2 = await eBTC.connect(bob)["unshield(address,address,uint64)"](bob.address, alice.address, unshieldAmount2);
       const requestId2 = await getUnshieldRequestId(tx2, eBTC);
 
       // Alice should have 2 pending claims
@@ -294,6 +294,64 @@ describe("FHERC20ERC20Wrapper", function () {
       const claimsAfter = await eBTC.getUserClaims(alice.address);
       expect(claimsAfter.length).to.equal(0);
     });
+
+    it("should complete unshield and claim flow with encrypted amount (euint64)", async function () {
+      const { eBTC, bob, alice, wBTC, bobClient } = await setupFixture();
+
+      const unshieldConfidentialValue = 1_000_000n;
+      const unshieldERC20Value = unshieldConfidentialValue * conversionRate; // 1e8
+
+      // Shield exactly the unshield amount so balance handle matches the desired value
+      await wBTC.mint(bob, unshieldERC20Value);
+      await wBTC.connect(bob).approve(eBTC.target, unshieldERC20Value);
+      await eBTC.connect(bob).shield(bob, unshieldERC20Value);
+
+      // Get bob's encrypted balance handle as the euint64 input
+      const encryptedAmount = await eBTC.confidentialBalanceOf(bob.address);
+
+      await prepExpectFHERC20BalancesChange(eBTC, bob.address);
+
+      const tx = await eBTC
+        .connect(bob)
+        ["unshield(address,address,bytes32)"](bob.address, alice.address, encryptedAmount);
+
+      await expect(tx).to.emit(eBTC, "Unshielded");
+      await expectFHERC20BalancesChange(eBTC, bob.address, -1n * unshieldConfidentialValue);
+
+      const unshieldRequestId = await getUnshieldRequestId(tx, eBTC);
+
+      // Verify claim was created via getClaim
+      const pendingClaim = await eBTC.getClaim(unshieldRequestId);
+      expect(pendingClaim.to).to.equal(alice.address);
+      expect(pendingClaim.requestedAmount).to.equal(0n);
+      expect(pendingClaim.claimed).to.equal(false);
+
+      // Verify getUserClaims tracks the pending claim
+      const aliceClaims = await eBTC.getUserClaims(alice.address);
+      expect(aliceClaims.length).to.equal(1);
+      expect(aliceClaims[0].ctHash).to.equal(unshieldRequestId);
+
+      // Time travel past decryption delay
+      await hre.network.provider.send("evm_increaseTime", [11]);
+      await hre.network.provider.send("evm_mine");
+
+      const decryption = await bobClient.decryptForTx(unshieldRequestId).withoutPermit().execute();
+
+      await prepExpectERC20BalancesChange(wBTC, alice.address);
+
+      await expect(
+        eBTC.connect(bob).claimUnshielded(unshieldRequestId, decryption.decryptedValue, decryption.signature),
+      ).to.emit(eBTC, "ClaimedUnshielded");
+
+      await expectERC20BalancesChange(wBTC, alice.address, unshieldERC20Value);
+
+      // Claim is marked as claimed and removed from user's pending claims
+      const claimedClaim = await eBTC.getClaim(unshieldRequestId);
+      expect(claimedClaim.claimed).to.equal(true);
+
+      const aliceClaimsAfter = await eBTC.getUserClaims(alice.address);
+      expect(aliceClaimsAfter.length).to.equal(0);
+    });
   });
 
   describe("unshield reverts", function () {
@@ -305,7 +363,7 @@ describe("FHERC20ERC20Wrapper", function () {
       await wBTC.connect(bob).approve(eBTC.target, mintValue);
       await eBTC.connect(bob).shield(bob, mintValue);
 
-      await expect(eBTC.connect(bob).unshield(bob.address, ZeroAddress, 1_000_000n)).to.be.revertedWithCustomError(
+      await expect(eBTC.connect(bob)["unshield(address,address,uint64)"](bob.address, ZeroAddress, 1_000_000n)).to.be.revertedWithCustomError(
         eBTC,
         "FHERC20InvalidReceiver",
       );
@@ -319,7 +377,7 @@ describe("FHERC20ERC20Wrapper", function () {
       await wBTC.connect(bob).approve(eBTC.target, mintValue);
       await eBTC.connect(bob).shield(bob, mintValue);
 
-      await expect(eBTC.connect(alice).unshield(bob.address, alice.address, 1_000_000n)).to.be.revertedWithCustomError(
+      await expect(eBTC.connect(alice)["unshield(address,address,uint64)"](bob.address, alice.address, 1_000_000n)).to.be.revertedWithCustomError(
         eBTC,
         "FHERC20UnauthorizedSpender",
       );
@@ -344,7 +402,7 @@ describe("FHERC20ERC20Wrapper", function () {
       await wBTC.connect(bob).approve(eBTC.target, mintValue);
       await eBTC.connect(bob).shield(bob, mintValue);
 
-      const tx = await eBTC.connect(bob).unshield(bob.address, alice.address, 1_000_000n);
+      const tx = await eBTC.connect(bob)["unshield(address,address,uint64)"](bob.address, alice.address, 1_000_000n);
       const requestId = await getUnshieldRequestId(tx, eBTC);
 
       await hre.network.provider.send("evm_increaseTime", [11]);

--- a/test/FHERC20NativeWrapper.test.ts
+++ b/test/FHERC20NativeWrapper.test.ts
@@ -233,7 +233,7 @@ describe("FHERC20NativeWrapper", function () {
 
       await prepExpectFHERC20BalancesChange(eETH, bob.address);
 
-      const tx = await eETH.connect(bob).unshield(bob.address, alice.address, unshieldConfidentialValue);
+      const tx = await eETH.connect(bob)["unshield(address,address,uint64)"](bob.address, alice.address, unshieldConfidentialValue);
 
       await expect(tx).to.emit(eETH, "Unshielded");
       await expectFHERC20BalancesChange(eETH, bob.address, -1n * unshieldConfidentialValue);
@@ -284,7 +284,7 @@ describe("FHERC20NativeWrapper", function () {
 
       await prepExpectFHERC20BalancesChange(eETH, bob.address);
 
-      const tx = await eETH.connect(alice).unshield(bob.address, alice.address, unshieldConfidentialValue);
+      const tx = await eETH.connect(alice)["unshield(address,address,uint64)"](bob.address, alice.address, unshieldConfidentialValue);
 
       await expect(tx).to.emit(eETH, "Unshielded");
       await expectFHERC20BalancesChange(eETH, bob.address, -1n * unshieldConfidentialValue);
@@ -311,11 +311,11 @@ describe("FHERC20NativeWrapper", function () {
       const unshieldAmount2 = 300_000n;
 
       // Create first unshield
-      const tx1 = await eETH.connect(bob).unshield(bob.address, alice.address, unshieldAmount1);
+      const tx1 = await eETH.connect(bob)["unshield(address,address,uint64)"](bob.address, alice.address, unshieldAmount1);
       const requestId1 = await getUnshieldRequestId(tx1, eETH);
 
       // Create second unshield
-      const tx2 = await eETH.connect(bob).unshield(bob.address, alice.address, unshieldAmount2);
+      const tx2 = await eETH.connect(bob)["unshield(address,address,uint64)"](bob.address, alice.address, unshieldAmount2);
       const requestId2 = await getUnshieldRequestId(tx2, eETH);
 
       // Alice should have 2 pending claims
@@ -346,6 +346,63 @@ describe("FHERC20NativeWrapper", function () {
       const claimsAfter = await eETH.getUserClaims(alice.address);
       expect(claimsAfter.length).to.equal(0);
     });
+
+    it("should complete unshield and claim flow with encrypted amount (euint64)", async function () {
+      const { eETH, bob, alice, bobClient } = await setupFixture();
+
+      const unshieldConfidentialValue = 1_000_000n;
+      const unshieldNativeValue = unshieldConfidentialValue * conversionRate; // 1e18
+
+      // Shield exactly the unshield amount so balance handle matches the desired value
+      await eETH.connect(bob).shieldNative(bob, { value: unshieldNativeValue });
+
+      // Get bob's encrypted balance handle as the euint64 input
+      const encryptedAmount = await eETH.confidentialBalanceOf(bob.address);
+
+      await prepExpectFHERC20BalancesChange(eETH, bob.address);
+
+      const tx = await eETH
+        .connect(bob)
+        ["unshield(address,address,bytes32)"](bob.address, alice.address, encryptedAmount);
+
+      await expect(tx).to.emit(eETH, "Unshielded");
+      await expectFHERC20BalancesChange(eETH, bob.address, -1n * unshieldConfidentialValue);
+
+      const unshieldRequestId = await getUnshieldRequestId(tx, eETH);
+
+      // Verify claim was created via getClaim
+      const pendingClaim = await eETH.getClaim(unshieldRequestId);
+      expect(pendingClaim.to).to.equal(alice.address);
+      expect(pendingClaim.requestedAmount).to.equal(0n);
+      expect(pendingClaim.claimed).to.equal(false);
+
+      // Verify getUserClaims tracks the pending claim
+      const aliceClaims = await eETH.getUserClaims(alice.address);
+      expect(aliceClaims.length).to.equal(1);
+      expect(aliceClaims[0].ctHash).to.equal(unshieldRequestId);
+
+      // Time travel past decryption delay
+      await hre.network.provider.send("evm_increaseTime", [11]);
+      await hre.network.provider.send("evm_mine");
+
+      const decryption = await bobClient.decryptForTx(unshieldRequestId).withoutPermit().execute();
+
+      const aliceBalanceBefore = await ethers.provider.getBalance(alice.address);
+
+      await expect(
+        eETH.connect(bob).claimUnshielded(unshieldRequestId, decryption.decryptedValue, decryption.signature),
+      ).to.emit(eETH, "ClaimedUnshielded");
+
+      const aliceBalanceAfter = await ethers.provider.getBalance(alice.address);
+      expect(aliceBalanceAfter - aliceBalanceBefore).to.equal(unshieldNativeValue);
+
+      // Claim is marked as claimed and removed from user's pending claims
+      const claimedClaim = await eETH.getClaim(unshieldRequestId);
+      expect(claimedClaim.claimed).to.equal(true);
+
+      const aliceClaimsAfter = await eETH.getUserClaims(alice.address);
+      expect(aliceClaimsAfter.length).to.equal(0);
+    });
   });
 
   describe("unshield reverts", function () {
@@ -354,7 +411,7 @@ describe("FHERC20NativeWrapper", function () {
 
       await eETH.connect(bob).shieldNative(bob, { value: ethers.parseEther("10") });
 
-      await expect(eETH.connect(bob).unshield(bob.address, ZeroAddress, 1_000_000n)).to.be.revertedWithCustomError(
+      await expect(eETH.connect(bob)["unshield(address,address,uint64)"](bob.address, ZeroAddress, 1_000_000n)).to.be.revertedWithCustomError(
         eETH,
         "FHERC20InvalidReceiver",
       );
@@ -365,7 +422,7 @@ describe("FHERC20NativeWrapper", function () {
 
       await eETH.connect(bob).shieldNative(bob, { value: ethers.parseEther("10") });
 
-      await expect(eETH.connect(alice).unshield(bob.address, alice.address, 1_000_000n)).to.be.revertedWithCustomError(
+      await expect(eETH.connect(alice)["unshield(address,address,uint64)"](bob.address, alice.address, 1_000_000n)).to.be.revertedWithCustomError(
         eETH,
         "FHERC20UnauthorizedSpender",
       );
@@ -387,7 +444,7 @@ describe("FHERC20NativeWrapper", function () {
 
       await eETH.connect(bob).shieldNative(bob, { value: ethers.parseEther("10") });
 
-      const tx = await eETH.connect(bob).unshield(bob.address, alice.address, 1_000_000n);
+      const tx = await eETH.connect(bob)["unshield(address,address,uint64)"](bob.address, alice.address, 1_000_000n);
       const requestId = await getUnshieldRequestId(tx, eETH);
 
       await hre.network.provider.send("evm_increaseTime", [11]);


### PR DESCRIPTION
## Summary

- Adds a new `unshield(address from, address to, euint64 amount)` overload that accepts an encrypted amount, alongside the existing `unshield(address, address, uint64)` plaintext version
- Extracts shared logic into an internal `_unshield` function used by both overloads
- The `euint64` overload checks `FHE.isAllowed(amount, msg.sender)` before proceeding, following the same ACL pattern used by `confidentialTransfer(address, euint64)` in FHERC20
- Applied to both ERC20 and Native wrapper contracts (including upgradeable variants)
- Existing tests updated to use explicit function selectors for disambiguation; new tests added for the `euint64` flow

### Note on `Claim.requestedAmount`

The `Claim` struct stores a `requestedAmount` (plaintext `uint64`) which is purely informational and its **never used** in `_handleClaim` or claim verification logic. For the encrypted overload, we pass `0` since the plaintext value is unknown at call time. This works but is arguably not the cleanest solution. A future improvement could remove `requestedAmount` from the struct entirely, or replace it with a flag indicating whether the original input was encrypted.

## Related work

OpenZeppelin's ERC7984 wrapper also has this encrypted unshield function:
https://github.com/OpenZeppelin/openzeppelin-confidential-contracts/blob/master/contracts/token/ERC7984/extensions/ERC7984ERC20Wrapper.sol#L104-L110
