### PR TITLE
fix(FHERC20): add `isInitialized` guard in `requestDiscloseEncryptedAmount`

### DIFF
--- a/contracts/FHERC20/FHERC20.sol
+++ b/contracts/FHERC20/FHERC20.sol
@@ -280,6 +280,12 @@ abstract contract FHERC20 is IFHERC20, Context, ERC165 {
      * `encryptedAmount` to request disclosure of the encrypted amount `encryptedAmount`.
      */
     function requestDiscloseEncryptedAmount(euint64 encryptedAmount) public virtual {
+        // Guard against uninitialized (zero) handles. Passing an uninitialized handle
+        // would pass the isAllowed check if the caller holds no permissions (allowPublic
+        // on a zero handle is a no-op but emits a misleading event), or it could interact
+        // with unrelated task-manager entries that share the zero-handle slot.
+        if (!FHE.isInitialized(encryptedAmount))
+            revert FHERC20ZeroBalance(msg.sender);
         if (!FHE.isAllowed(encryptedAmount, msg.sender))
             revert FHERC20UnauthorizedUseOfEncryptedAmount(encryptedAmount, msg.sender);
 


### PR DESCRIPTION
## Summary

`requestDiscloseEncryptedAmount` checks whether `msg.sender` is permitted to use `encryptedAmount` via `FHE.isAllowed`, but does **not** first verify that `encryptedAmount` is an initialized (non-zero) handle. Passing an uninitialized handle produces confusing behavior.

## Bug

```solidity
// Before
function requestDiscloseEncryptedAmount(euint64 encryptedAmount) public virtual {
    if (!FHE.isAllowed(encryptedAmount, msg.sender))
        revert FHERC20UnauthorizedUseOfEncryptedAmount(encryptedAmount, msg.sender);
    //  ↑ isAllowed on a zero handle depends on whether zero has been globally permitted.
    //    In normal operation this reverts, but the error is misleading.
    //    If zero has global permissions, execution continues and calls allowPublic(0).

    FHE.allowPublic(encryptedAmount);               // ← called with handle 0
    emit AmountDiscloseRequested(encryptedAmount, msg.sender);  // ← misleading event
}
```

The existing pattern in `_update` (line ~364) correctly guards against uninitialized handles:
```solidity
if (!FHE.isInitialized(fromBalance)) revert FHERC20ZeroBalance(from);
```

## Fix

Add the same guard as the first check in `requestDiscloseEncryptedAmount`:

```solidity
if (!FHE.isInitialized(encryptedAmount))
    revert FHERC20ZeroBalance(msg.sender);
```