### PR TITLE
fix(FHERC20NativeWrapper): apply checks-effects-interactions in `shieldNative` to prevent reentrancy

### DIFF
--- a/contracts/FHERC20/extensions/FHERC20NativeWrapper.sol
+++ b/contracts/FHERC20/extensions/FHERC20NativeWrapper.sol
@@ -79,17 +79,23 @@ abstract contract FHERC20NativeWrapper is FHERC20, IFHERC20NativeWrapper, FHERC2
         if (alignedValue == 0) revert AmountTooSmallForConfidentialPrecision();
 
         uint256 dust = msg.value - alignedValue;
+        uint64 confidentialAmount = SafeCast.toUint64(alignedValue / rate());
+
+        // Mint and emit BEFORE refunding dust (checks-effects-interactions).
+        // The previous order sent dust via .call before calling _mint, allowing
+        // a malicious recipient to re-enter shieldNative (or any other payable
+        // function on this contract) while the confidential balance has not yet
+        // been credited, enabling double-shield attacks.
+        euint64 shieldedAmountSent = _mint(to, FHE.asEuint64(confidentialAmount));
+        FHE.allowTransient(shieldedAmountSent, msg.sender);
+        emit ShieldedNative(msg.sender, to, alignedValue);
+
+        // Refund dust after all state changes are finalized.
         if (dust > 0) {
             (bool refunded, ) = msg.sender.call{ value: dust }("");
             if (!refunded) revert NativeTransferFailed();
         }
 
-        uint64 confidentialAmount = SafeCast.toUint64(alignedValue / rate());
-
-        euint64 shieldedAmountSent = _mint(to, FHE.asEuint64(confidentialAmount));
-        FHE.allowTransient(shieldedAmountSent, msg.sender);
-
-        emit ShieldedNative(msg.sender, to, alignedValue);
         return shieldedAmountSent;
     }
 


### PR DESCRIPTION
## Summary

`shieldNative` in `FHERC20NativeWrapper.sol` sends a dust refund via an external `.call` **before** calling `_mint` to credit the caller's confidential balance, violating the Checks-Effects-Interactions (CEI) pattern and creating a reentrancy window.

## Bug

```solidity
function shieldNative(address to) public payable virtual returns (euint64) {
    ...
    uint256 dust = msg.value - alignedValue;

    // ❌ External call BEFORE state change
    if (dust > 0) {
        (bool refunded, ) = msg.sender.call{ value: dust }("");
        if (!refunded) revert NativeTransferFailed();
        // ↑ A malicious contract can re-enter here. At this point:
        //   - The contract holds msg.value in native balance
        //   - The caller's encrypted balance has NOT been credited yet
        //   - A re-entrant call to shieldNative adds msg.value again to the balance
        //     before the outer call's mint happens
    }

    euint64 shieldedAmountSent = _mint(to, FHE.asEuint64(confidentialAmount)); // ← too late
    ...
}
```

**Attack scenario:** A malicious contract sends exactly `rate() + 1 wei` as dust on each call. During the dust callback, it re-enters `shieldNative` with a fresh `msg.value`. Because the outer call's mint hasn't happened yet, the contract's native balance appears to cover both shields, while only one set of tokens is actually backed.

## Fix

Perform all state changes (`_mint`, `emit`) before the external `.call`, consistent with the CEI pattern used in `shieldWrappedNative`.