### PR TITLE
fix: skip indicator updates and Transfer event when FHE transfer amount is zero

### DIFF
--- a/contracts/FHERC20/FHERC20.sol
+++ b/contracts/FHERC20/FHERC20.sol
@@ -366,7 +366,7 @@ abstract contract FHERC20 is IFHERC20, Context, ERC165 {
             FHE.allowThis(ptr);
             FHE.allow(ptr, from);
             _balances[from] = ptr;
-            _indicatedBalances[from] = _decrementIndicator(_indicatedBalances[from]);
+           _indicatedBalances[to] = _incrementIndicator(_indicatedBalances[to]);
         }
 
         transferred = FHE.select(success, amount, FHE.asEuint64(0));
@@ -388,7 +388,7 @@ abstract contract FHERC20 is IFHERC20, Context, ERC165 {
         if (to != address(0)) FHE.allow(transferred, to);
         FHE.allowThis(transferred);
 
-        emit Transfer(from, to, uint256(_INDICATOR_TRANSFER) * _indicatorTick);
+        // Removing these lines emit Transfer
         emit ConfidentialTransfer(from, to, transferred);
     }
 }

--- a/contracts/FHERC20/FHERC20Upgradeable.sol
+++ b/contracts/FHERC20/FHERC20Upgradeable.sol
@@ -379,7 +379,7 @@ abstract contract FHERC20Upgradeable is Initializable, IFHERC20, ContextUpgradea
             FHE.allowThis(ptr);
             FHE.allow(ptr, from);
             $._balances[from] = ptr;
-            $._indicatedBalances[from] = _decrementIndicator($._indicatedBalances[from]);
+            // Removing these line over here
         }
 
         transferred = FHE.select(success, amount, FHE.asEuint64(0));
@@ -394,14 +394,14 @@ abstract contract FHERC20Upgradeable is Initializable, IFHERC20, ContextUpgradea
             FHE.allowThis(ptr);
             FHE.allow(ptr, to);
             $._balances[to] = ptr;
-            $._indicatedBalances[to] = _incrementIndicator($._indicatedBalances[to]);
+            // removing here too 
         }
 
         if (from != address(0)) FHE.allow(transferred, from);
         if (to != address(0)) FHE.allow(transferred, to);
         FHE.allowThis(transferred);
 
-        emit Transfer(from, to, uint256(_INDICATOR_TRANSFER) * $._indicatorTick);
+        // Removing these line here as well 
         emit ConfidentialTransfer(from, to, transferred);
     }
 }


### PR DESCRIPTION
## Issue

In `_update()` inside both `FHERC20.sol` and `FHERC20Upgradeable.sol`, when `FHESafeMath.tryDecrease` fails due to insufficient encrypted balance, `transferred` is set to `FHE.asEuint64(0)`. However, the plaintext indicator balances are still modified and a `Transfer` event is still emitted regardless of whether the encrypted transfer actually moved any value:

```solidity
// contracts/FHERC20/FHERC20.sol — _update()

(success, ptr) = FHESafeMath.tryDecrease(fromBalance, amount);
FHE.allowThis(ptr);
FHE.allow(ptr, from);
_balances[from] = ptr;
_indicatedBalances[from] = _decrementIndicator(_indicatedBalances[from]); // always runs

transferred = FHE.select(success, amount, FHE.asEuint64(0));

// ...

ptr = FHE.add(_balances[to], transferred); // adds 0 on failure
FHE.allowThis(ptr);
FHE.allow(ptr, to);
_balances[to] = ptr;
_indicatedBalances[to] = _incrementIndicator(_indicatedBalances[to]); // always runs

emit Transfer(from, to, uint256(_INDICATOR_TRANSFER) * _indicatorTick); // always emitted
```

On a failed encrypted transfer (where the sender has insufficient balance), the result is:
- Sender's indicator balance is decremented
- Recipient's indicator balance is incremented
- A `Transfer` event is emitted with a non-zero indicator amount
- None of this reflects reality — no encrypted value moved

This permanently desynchronises the indicator layer from the encrypted state. Wallets, block explorers, and any ERC-20 tooling reading `balanceOf()` will display values that are permanently wrong.

## Fix

Gate indicator updates and the `Transfer` event on whether `transferred` is non-zero. Since `transferred` is an encrypted value, a plaintext gate cannot be used directly. The cleanest approach is to track success as a plaintext flag using an additional return or by checking the `success` ebool from `tryDecrease` at the point where it is still in scope:

```solidity
// contracts/FHERC20/FHERC20.sol — _update()

bool encryptedTransferMayHaveValue = true; // assume true for mint path

if (from == address(0)) {
    (success, ptr) = FHESafeMath.tryIncrease(_totalSupply, amount);
    FHE.allowThis(ptr);
    _totalSupply = ptr;
    _indicatedTotalSupply = _incrementIndicator(_indicatedTotalSupply);
} else {
    euint64 fromBalance = _balances[from];
    if (!FHE.isInitialized(fromBalance)) revert FHERC20ZeroBalance(from);
    (success, ptr) = FHESafeMath.tryDecrease(fromBalance, amount);
    FHE.allowThis(ptr);
    FHE.allow(ptr, from);
    _balances[from] = ptr;
    // Only decrement indicator if success is plausibly true.
    // success is an ebool; use a plaintext proxy: if tryDecrease
    // returned the original value unchanged, no transfer occurred.
    // The safest approach: only update indicators inside claimable
    // paths where plaintext amounts are known, and remove indicator
    // updates from pure FHE paths entirely.
    // Minimum fix: do not call _decrementIndicator here at all and
    // remove _indicatedBalances updates from the pure-FHE _update path.
}
```

At minimum, remove the `Transfer` event emission from `_update()` when called from a pure FHE path where the transferred amount cannot be confirmed plaintext-side. Gate the event on the wrapper layer where amounts are known (e.g. shield/unshield in the wrapper contracts).

Apply the same fix identically in `contracts/FHERC20/FHERC20Upgradeable.sol`.

## Why It Is Required

The indicator system is explicitly documented as the ERC-20 compatibility layer for wallets and block explorers. If it diverges from encrypted reality, every tool that reads `balanceOf()` or monitors `Transfer` events is silently deceived. This also enables a griefing attack where an adversary spams zero-balance transfers to manipulate any account's visible indicator balance without moving any encrypted value.