### PR TITLE
feat: ledger-agnostic confidential core (Core + Lib + interface)

### DIFF
--- a/contracts/ERC20Confidential/ERC20ConfidentialCoreUpgradeable.sol
+++ b/contracts/ERC20Confidential/ERC20ConfidentialCoreUpgradeable.sol
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import { FHE, euint64, InEuint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+import { IERC20ConfidentialCore } from "../interfaces/IERC20ConfidentialCore.sol";
+import { ERC20ConfidentialIndicator } from "./ERC20ConfidentialIndicator.sol";
+import { ERC20ConfidentialLib } from "./ERC20ConfidentialLib.sol";
+import { ReentrancyGuardTransient } from "@openzeppelin/contracts/utils/ReentrancyGuardTransient.sol";
+
+/**
+ * @title ERC20ConfidentialCoreUpgradeable
+ * @notice Ledger-agnostic, OZ-base-free variant of {ERC20ConfidentialUpgradeable}. It carries the
+ * FULL confidential (FHE) layer — shield/unshield, confidential transfers, operators,
+ * `_confidentialUpdate` — but inherits NO public ERC-20 implementation and NO OpenZeppelin base
+ * contracts (`ERC20Upgradeable`, `ERC165Upgradeable`, `Initializable`). It reaches the host's
+ * public ledger through three hooks ({_ledgerMint}, {_ledgerTransfer}, {_ledgerBalanceOf}).
+ *
+ * Why no OZ bases: this core is meant to be mixed into a contract that ALREADY brings its own
+ * ledger + OZ stack (e.g. M0's `ERC20ExtendedUpgradeable` reached via `JMIExtension`, which vendors
+ * its own copy of OpenZeppelin). Inheriting OZ here would put a SECOND `Initializable` / `IERC165`
+ * into the combined inheritance graph and fail to compile ("Identifier already declared"). So:
+ *   - The confidential-only {IERC20ConfidentialCore} interface does not extend OZ `IERC20`/`IERC165`.
+ *   - The claim helper {FHERC20WrapperClaimHelperCore} drops OZ `Initializable`.
+ *   - Init is plain `internal`; the HOST's initializer (its own `Initializable`) guards one-time setup.
+ *
+ * This is a NEW contract; {ERC20ConfidentialUpgradeable} is left untouched. State lives in the SAME
+ * ERC-7201 slot (`fherc20.storage.ERC20Confidential`) so the confidential layout is portable.
+ */
+abstract contract ERC20ConfidentialCoreUpgradeable is IERC20ConfidentialCore, ReentrancyGuardTransient {
+    using ERC20ConfidentialLib for ERC20ConfidentialLib.ERC20ConfidentialStorage;
+
+    address public constant CONFIDENTIAL_POOL = address(0x1011000000000000000000000000000000000000);
+
+    // The confidential storage struct lives in ERC20ConfidentialLib so the library and this
+    // contract share one type (the library mutates it via delegatecall). Same ERC-7201 slot.
+    // keccak256(abi.encode(uint256(keccak256("fherc20.storage.ERC20Confidential")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant ERC20ConfidentialStorageLocation =
+        0xb440e9c559aceef9e2c75ec16e8d26ee97396e4a6978215085407b7ab0709e00;
+
+    function _getERC20ConfidentialStorage()
+        private
+        pure
+        returns (ERC20ConfidentialLib.ERC20ConfidentialStorage storage $)
+    {
+        assembly {
+            $.slot := ERC20ConfidentialStorageLocation
+        }
+    }
+
+    error ERC20ConfidentialUnauthorizedUseOfEncryptedAmount(euint64 value, address user);
+    error ERC20ConfidentialUnauthorizedSpender(address holder, address spender);
+    error AmountTooSmallForConfidentialPrecision();
+    error ConfidentialInvalidSender(address sender);
+    error ConfidentialInvalidReceiver(address receiver);
+    error NotSelf();
+    error ClaimBatchLengthMismatch();
+
+    // =========================================================================
+    //  Ledger hooks — implemented by the host (its public ERC-20 ledger)
+    // =========================================================================
+
+    /// @dev Mint `amount` of the PUBLIC token to `to`. Host forwards to its ledger's `_mint`.
+    function _ledgerMint(address to, uint256 amount) internal virtual;
+
+    /// @dev Move `amount` of the PUBLIC token from `from` to `to`. Host forwards to `_transfer`.
+    function _ledgerTransfer(address from, address to, uint256 amount) internal virtual;
+
+    /// @dev Public token balance of `account`. Host forwards to its ledger's `balanceOf`.
+    function _ledgerBalanceOf(address account) internal view virtual returns (uint256);
+
+    // =========================================================================
+    //  Initializer (no ERC-20 init, no Initializable — host guards the call).
+    //  `name`/`symbol` are passed in (not read via name()/symbol()) so the
+    //  confidential layer never owns the public-ledger metadata — that stays
+    //  entirely with the host ERC-20, avoiding an external-vs-public override clash.
+    // =========================================================================
+
+    /// @param publicDecimals_       Decimals of the host's PUBLIC ERC-20 ledger (e.g. 6 for M0).
+    /// @param confidentialDecimals_ Desired decimals of the confidential layer; clamped to
+    ///        `publicDecimals_` since the confidential side can be no finer than the public ledger
+    ///        backing it. The conversion rate is then `10 ** (publicDecimals_ - confidentialDecimals)`,
+    ///        so one confidential unit is backed by exactly that many public base units.
+    function __ERC20ConfidentialCore_init(uint8 publicDecimals_, uint8 confidentialDecimals_) internal {
+        ERC20ConfidentialLib.ERC20ConfidentialStorage storage $ = _getERC20ConfidentialStorage();
+        uint8 confDecimals = confidentialDecimals_ <= publicDecimals_ ? confidentialDecimals_ : publicDecimals_;
+        $._decimals = publicDecimals_;
+        $._confidentialDecimals = confDecimals;
+        $._conversionRate = 10 ** (publicDecimals_ - confDecimals);
+    }
+
+    /// @dev Wire an externally-deployed indicator token. Kept out of the initializer (and not
+    /// `new`-ed here) so the indicator's ~2.4 KB of creation code is NOT embedded into the host's
+    /// bytecode — important for the size-constrained JMI fusion. Optional: confidential transfers
+    /// work without an indicator; if set, they emit indicator mirror events.
+    function _setIndicatorToken(ERC20ConfidentialIndicator token) internal {
+        _getERC20ConfidentialStorage()._indicatorToken = token;
+    }
+
+    function confidentialDecimals() public view virtual returns (uint8) {
+        return _getERC20ConfidentialStorage()._confidentialDecimals;
+    }
+
+    function contractURI() public view virtual returns (string memory) {
+        return "";
+    }
+
+    function indicatorToken() public view virtual returns (ERC20ConfidentialIndicator) {
+        return _getERC20ConfidentialStorage()._indicatorToken;
+    }
+
+    /// @notice The compliance observer that gains FHE access to confidential values
+    ///         (address(0) = none). Set via a host's role-gated entry point.
+    function observer() public view virtual returns (address) {
+        return _getERC20ConfidentialStorage()._observer;
+    }
+
+    /// @dev Set the compliance observer. Forward access is granted in `update()`;
+    /// past handles are topped up via `ERC20ConfidentialLib.grantPast`. Hosts wrap
+    /// this behind access control.
+    function _setObserver(address observer_) internal {
+        _getERC20ConfidentialStorage()._observer = observer_;
+    }
+
+    /// @dev `false` because {balanceOf} returns the real public ERC-20 balance, not an indicator.
+    function balanceOfIsIndicator() public pure virtual returns (bool) {
+        return false;
+    }
+
+    /// @dev Always `0`: {balanceOf} is not an indicator on this token.
+    function indicatorTick() public pure virtual returns (uint256) {
+        return 0;
+    }
+
+    /// @dev Derived on read from {CONFIDENTIAL_POOL}'s public balance, scaled to confidential
+    /// decimals. The returned handle is not a registered ciphertext, so it is informational only.
+    function confidentialTotalSupply() public view virtual returns (euint64) {
+        return euint64.wrap(bytes32(_ledgerBalanceOf(CONFIDENTIAL_POOL) / _rate()));
+    }
+
+    function confidentialBalanceOf(address account) public view virtual returns (euint64) {
+        return _getERC20ConfidentialStorage()._confidentialBalances[account];
+    }
+
+    function isOperator(address holder, address spender) public view virtual returns (bool) {
+        return holder == spender || block.timestamp <= _getERC20ConfidentialStorage()._operators[holder][spender];
+    }
+
+    /// @dev The confidential interface id. The host's `supportsInterface` should OR this in.
+    function _confidentialSupportsInterface(bytes4 interfaceId) internal pure returns (bool) {
+        return interfaceId == type(IERC20ConfidentialCore).interfaceId;
+    }
+
+    // =========================================================================
+    //  Shield / Unshield
+    // =========================================================================
+
+    // Thin wrappers — orchestration relocated to ERC20ConfidentialLib (EIP-170).
+    // Ledger ops reach back through the self-only `__ledger` bridge below. The guard
+    // hook stays here so the host's override is invoked.
+
+    // No reentrancy guard: shield's only external call is the self-call to `__ledger`
+    // (→ the host's public `_transfer`), which does not hand control to untrusted code,
+    // and it moves no confidential balance that a callback could race.
+    function shield(uint256 amount) public virtual {
+        ERC20ConfidentialLib.shield(_getERC20ConfidentialStorage(), amount);
+    }
+
+    function unshield(uint64 amount) public virtual nonReentrant returns (euint64) {
+        _beforeConfidentialMove(msg.sender, address(0));
+        return ERC20ConfidentialLib.unshield(_getERC20ConfidentialStorage(), FHE.asEuint64(amount), amount);
+    }
+
+    function unshield(euint64 amount) public virtual nonReentrant returns (euint64) {
+        _beforeConfidentialMove(msg.sender, address(0));
+        return ERC20ConfidentialLib.unshieldChecked(_getERC20ConfidentialStorage(), amount);
+    }
+
+    // No reentrancy guard: the only external call is the self-call to `__ledger`
+    // (→ the host's public `_transfer`), which hands control to no untrusted code;
+    // replay is already prevented by the claim's `claimed` flag in `handleClaim`.
+    // `id` is the unique claim id from {getClaim}/{getUserClaims} (NOT the ciphertext handle).
+    function claimUnshielded(
+        bytes32 id,
+        uint64 decryptedAmount,
+        bytes calldata decryptionProof
+    ) public virtual {
+        ERC20ConfidentialLib.claimUnshielded(_getERC20ConfidentialStorage(), id, decryptedAmount, decryptionProof);
+    }
+
+    // No reentrancy guard: same rationale as {claimUnshielded}. Each `ids[i]` is the unique
+    // claim id from {getClaim}/{getUserClaims} (NOT the ciphertext handle).
+    function claimUnshieldedBatch(
+        bytes32[] calldata ids,
+        uint64[] calldata decryptedAmounts,
+        bytes[] calldata decryptionProofs
+    ) public virtual {
+        if (ids.length != decryptedAmounts.length || ids.length != decryptionProofs.length) {
+            revert ClaimBatchLengthMismatch();
+        }
+        ERC20ConfidentialLib.ERC20ConfidentialStorage storage $ = _getERC20ConfidentialStorage();
+        for (uint256 i = 0; i < ids.length; i++) {
+            ERC20ConfidentialLib.claimUnshielded($, ids[i], decryptedAmounts[i], decryptionProofs[i]);
+        }
+    }
+
+    /// @dev Self-only ledger bridges: the delegatecall'd library calls these on the
+    /// host (an external self-call), which forwards to the host's ledger hooks.
+    function __ledger(address from, address to, uint256 amount) external {
+        if (msg.sender != address(this)) revert NotSelf();
+        if (from == address(0)) _ledgerMint(to, amount);
+        else _ledgerTransfer(from, to, amount);
+    }
+
+    /// @notice Pending-claim views (delegated to the library, which owns the claim storage).
+    /// @dev Keyed by the unique claim id (the `id` field of {ERC20ConfidentialLib.Claim}),
+    /// not by the ciphertext handle.
+    function getClaim(bytes32 id) public view virtual returns (ERC20ConfidentialLib.Claim memory) {
+        return ERC20ConfidentialLib.getClaim(id);
+    }
+
+    function getUserClaims(address user) public view virtual returns (ERC20ConfidentialLib.Claim[] memory) {
+        return ERC20ConfidentialLib.getUserClaims(user);
+    }
+
+    // =========================================================================
+    //  Confidential Transfers
+    // =========================================================================
+
+    // Thin wrappers — the full orchestration lives in ERC20ConfidentialLib (delegatecall'd) so its
+    // code isn't embedded in the host token. msg.sender/this are preserved under delegatecall.
+
+    /// @dev Hook invoked before every account-initiated confidential balance move
+    /// (transfers + unshield). Default no-op; hosts override to enforce policy
+    /// (e.g. freeze/pause). Issuer mint/burn deliberately do NOT call this.
+    function _beforeConfidentialMove(address from, address to) internal virtual {}
+
+    function confidentialTransfer(address to, euint64 value) public virtual nonReentrant returns (euint64) {
+        _beforeConfidentialMove(msg.sender, to);
+        return ERC20ConfidentialLib.confTransfer(_getERC20ConfidentialStorage(), to, value);
+    }
+
+    function confidentialTransfer(address to, InEuint64 memory inValue) public virtual nonReentrant returns (euint64) {
+        _beforeConfidentialMove(msg.sender, to);
+        return ERC20ConfidentialLib.confTransferIn(_getERC20ConfidentialStorage(), to, inValue);
+    }
+
+    function confidentialTransferFrom(
+        address from,
+        address to,
+        euint64 value
+    ) public virtual nonReentrant returns (euint64) {
+        _beforeConfidentialMove(from, to);
+        return ERC20ConfidentialLib.confTransferFrom(_getERC20ConfidentialStorage(), from, to, value);
+    }
+
+    function confidentialTransferFrom(
+        address from,
+        address to,
+        InEuint64 memory inValue
+    ) public virtual nonReentrant returns (euint64) {
+        _beforeConfidentialMove(from, to);
+        return ERC20ConfidentialLib.confTransferFromIn(_getERC20ConfidentialStorage(), from, to, inValue);
+    }
+
+    function confidentialTransferAndCall(
+        address to,
+        euint64 amount,
+        bytes calldata data
+    ) public virtual nonReentrant returns (euint64) {
+        _beforeConfidentialMove(msg.sender, to);
+        return ERC20ConfidentialLib.confTransferAndCall(_getERC20ConfidentialStorage(), to, amount, data);
+    }
+
+    function confidentialTransferAndCall(
+        address to,
+        InEuint64 memory encryptedAmount,
+        bytes calldata data
+    ) public virtual nonReentrant returns (euint64) {
+        _beforeConfidentialMove(msg.sender, to);
+        return ERC20ConfidentialLib.confTransferAndCallIn(_getERC20ConfidentialStorage(), to, encryptedAmount, data);
+    }
+
+    function confidentialTransferFromAndCall(
+        address from,
+        address to,
+        euint64 amount,
+        bytes calldata data
+    ) public virtual nonReentrant returns (euint64) {
+        _beforeConfidentialMove(from, to);
+        return ERC20ConfidentialLib.confTransferFromAndCall(_getERC20ConfidentialStorage(), from, to, amount, data);
+    }
+
+    function confidentialTransferFromAndCall(
+        address from,
+        address to,
+        InEuint64 memory encryptedAmount,
+        bytes calldata data
+    ) public virtual nonReentrant returns (euint64) {
+        _beforeConfidentialMove(from, to);
+        return
+            ERC20ConfidentialLib.confTransferFromAndCallIn(
+                _getERC20ConfidentialStorage(),
+                from,
+                to,
+                encryptedAmount,
+                data
+            );
+    }
+
+    // =========================================================================
+    //  Operators
+    // =========================================================================
+
+    function setOperator(address operator, uint48 until) public virtual {
+        _setOperator(msg.sender, operator, until);
+    }
+
+    // =========================================================================
+    //  Confidential Mint (for inheriting contracts)
+    // =========================================================================
+
+    function _confidentialMint(address to, uint64 amount) internal virtual {
+        ERC20ConfidentialLib.confidentialMint(_getERC20ConfidentialStorage(), to, amount);
+    }
+
+    // =========================================================================
+    //  Internal helpers
+    // =========================================================================
+
+    /// @dev Thin wrapper: the heavy encrypted-balance logic lives in {ERC20ConfidentialLib.update}
+    /// (a linked library, delegatecall'd) so it isn't embedded in the host token's bytecode.
+    function _confidentialUpdate(
+        address from,
+        address to,
+        euint64 amount
+    ) internal virtual returns (euint64 transferred) {
+        return ERC20ConfidentialLib.update(_getERC20ConfidentialStorage(), from, to, amount);
+    }
+
+    function _setOperator(address holder, address operator, uint48 until) internal virtual {
+        _getERC20ConfidentialStorage()._operators[holder][operator] = until;
+        emit OperatorSet(holder, operator, until);
+    }
+
+    function _rate() internal view virtual returns (uint256) {
+        return _getERC20ConfidentialStorage()._conversionRate;
+    }
+}

--- a/contracts/ERC20Confidential/ERC20ConfidentialLib.sol
+++ b/contracts/ERC20Confidential/ERC20ConfidentialLib.sol
@@ -1,0 +1,422 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { FHE, euint64, InEuint64, ebool } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import { FHESafeMath } from "../utils/FHESafeMath.sol";
+import { FHERC20Utils } from "../FHERC20/utils/FHERC20Utils.sol";
+import { ERC20ConfidentialIndicator } from "./ERC20ConfidentialIndicator.sol";
+
+/// @dev Self-only bridge the host token exposes so this delegatecall'd library can
+/// reach the host's ledger hooks (`_ledgerTransfer` / `_ledgerMint`) for the
+/// shield / unshield-claim / mint orchestration relocated here.
+interface IConfidentialLedger {
+    /// @dev `from == address(0)` ⇒ ledger mint; otherwise ledger transfer.
+    function __ledger(address from, address to, uint256 amount) external;
+}
+
+/**
+ * @title  ERC20ConfidentialLib
+ * @notice External (linked, delegatecall'd) home for the heaviest confidential balance logic, so
+ *         that code lives in this library's own deployed bytecode instead of being embedded in
+ *         every host token. Used by {ERC20ConfidentialCoreUpgradeable} to keep a token that fuses
+ *         the confidential layer with a large base (e.g. M0's `JMIExtension`) under the EIP-170
+ *         24 KB limit WITHOUT dropping any functionality.
+ *
+ * @dev    `public` library functions → the compiler emits `delegatecall`, so they run in the
+ *         HOST's context: `address(this)` is the token and `msg.sender` is the original caller —
+ *         exactly what the FHE ACL grants (`allowThis` / `allow(_, msg.sender)`) and the operator
+ *         checks need. The storage struct is passed by reference (resolves to the host's ERC-7201
+ *         slot) and is defined HERE so host and library share one type. Functions that need the
+ *         host's public ledger (`shield`/`unshield`/mint) stay in the host; everything purely
+ *         confidential lives here.
+ */
+library ERC20ConfidentialLib {
+    /// @custom:storage-location erc7201:fherc20.storage.ERC20Confidential
+    struct ERC20ConfidentialStorage {
+        mapping(address => euint64) _confidentialBalances;
+        mapping(address => mapping(address => uint48)) _operators;
+        ERC20ConfidentialIndicator _indicatorToken;
+        uint8 _decimals;
+        uint8 _confidentialDecimals;
+        uint256 _conversionRate;
+        // Compliance observer (ERC-7984-style). When set, every confidential
+        // balance handle produced by `update()` is also FHE.allow'd to it, so the
+        // observer can decrypt going forward. Past handles are topped up via
+        // `grantPast`. Append-only field — keep last for storage-layout safety.
+        address _observer;
+    }
+
+    // Pool that custodies the public ledger tokens backing confidential balances.
+    // Mirrors the constant in ERC20ConfidentialCoreUpgradeable.
+    address constant CONFIDENTIAL_POOL = address(0x1011000000000000000000000000000000000000);
+
+    event ConfidentialTransfer(address indexed from, address indexed to, euint64 indexed amount);
+    // Signatures (and indexed-ness) must match IERC20ConfidentialCore so the
+    // host token's ABI/topics are unchanged when these are emitted via delegatecall.
+    event TokensShielded(address indexed account, uint256 amount);
+    event TokensUnshielded(address indexed account, euint64 indexed amount);
+    event UnshieldedTokensClaimed(
+        address indexed account,
+        bytes32 indexed unshieldRequestId,
+        euint64 indexed unshieldAmount,
+        uint64 unshieldAmountCleartext
+    );
+
+    error ERC20ConfidentialUnauthorizedUseOfEncryptedAmount(euint64 value, address user);
+    error ERC20ConfidentialUnauthorizedSpender(address holder, address spender);
+    error ConfidentialInvalidSender(address sender);
+    error ConfidentialInvalidReceiver(address receiver);
+    error AmountTooSmallForConfidentialPrecision();
+
+    // =========================================================================
+    //  Core encrypted balance update (also used by the host for shield/mint)
+    // =========================================================================
+
+    /// @dev Saturating decrease on `from`, increase on `to`, ACL grants, indicator mirror, and the
+    /// {ConfidentialTransfer} log. Returns the actually-moved (clamped) amount.
+    function update(
+        ERC20ConfidentialStorage storage $,
+        address from,
+        address to,
+        euint64 amount
+    ) public returns (euint64 transferred) {
+        ebool success;
+        euint64 ptr;
+        address obs = $._observer; // compliance observer (0 = none); forward-grant below
+
+        if (from != address(0)) {
+            euint64 fromBalance = $._confidentialBalances[from];
+            (success, ptr) = FHESafeMath.tryDecrease(fromBalance, amount);
+            FHE.allowThis(ptr);
+            FHE.allow(ptr, from);
+            if (obs != address(0)) FHE.allow(ptr, obs);
+            $._confidentialBalances[from] = ptr;
+        }
+
+        transferred = from != address(0) ? FHE.select(success, amount, FHE.asEuint64(0)) : amount;
+
+        if (to != address(0)) {
+            ptr = FHE.add($._confidentialBalances[to], transferred);
+            FHE.allowThis(ptr);
+            FHE.allow(ptr, to);
+            if (obs != address(0)) FHE.allow(ptr, obs);
+            $._confidentialBalances[to] = ptr;
+        }
+
+        if (from != address(0)) FHE.allow(transferred, from);
+        if (to != address(0)) FHE.allow(transferred, to);
+        FHE.allowThis(transferred);
+        if (obs != address(0)) FHE.allow(transferred, obs);
+
+        ERC20ConfidentialIndicator ind = $._indicatorToken;
+        if (address(ind) != address(0)) ind.emitConfidentialTransfer(from, to);
+
+        emit ConfidentialTransfer(from, to, transferred);
+    }
+
+    // =========================================================================
+    //  Compliance observer — past-value top-up
+    // =========================================================================
+
+    /// @dev Grant `observer` FHE access to historical ciphertext handles the host
+    /// already owns (`allowThis`'d) — past transfer amounts (from {ConfidentialTransfer}
+    /// events) and/or current balance handles (from `confidentialBalanceOf`). Closes
+    /// the forward-only gap of the observer hook in `update()`.
+    ///
+    /// Runs under delegatecall, so `FHE.allow` executes as the host token, which holds
+    /// permanent ACL on every handle it created. NOTE: on real CoFHE, a ctHash the host
+    /// never owned reverts the whole call — the off-chain indexer must supply only this
+    /// token's handles.
+    function grantPast(address observer, uint256[] calldata ctHashes) public {
+        for (uint256 i = 0; i < ctHashes.length; i++) {
+            FHE.allow(euint64.wrap(bytes32(ctHashes[i])), observer);
+        }
+    }
+
+    // =========================================================================
+    //  Shield / unshield / mint orchestration (relocated from the host token to
+    //  fit under EIP-170; ledger ops reach the host via the self-only bridge).
+    // =========================================================================
+
+    function shield(ERC20ConfidentialStorage storage $, uint256 amount) public {
+        uint256 rate = $._conversionRate;
+        uint256 amountToShield = amount - (amount % rate);
+        if (amountToShield == 0) revert AmountTooSmallForConfidentialPrecision();
+
+        uint64 amountConfidential = SafeCast.toUint64(amountToShield / rate);
+
+        IConfidentialLedger(address(this)).__ledger(msg.sender, CONFIDENTIAL_POOL, amountToShield);
+        update($, address(0), msg.sender, FHE.asEuint64(amountConfidential));
+
+        emit TokensShielded(msg.sender, amountToShield);
+    }
+
+    function unshield(
+        ERC20ConfidentialStorage storage $,
+        euint64 amount,
+        uint64 requestedAmount
+    ) public returns (euint64 burned) {
+        burned = update($, msg.sender, address(0), amount);
+        FHE.allowPublic(burned);
+        createClaim(msg.sender, requestedAmount, burned);
+        emit TokensUnshielded(msg.sender, burned);
+    }
+
+    function unshieldChecked(ERC20ConfidentialStorage storage $, euint64 amount) public returns (euint64) {
+        if (!FHE.isAllowed(amount, msg.sender)) {
+            revert ERC20ConfidentialUnauthorizedUseOfEncryptedAmount(amount, msg.sender);
+        }
+        return unshield($, amount, 0);
+    }
+
+    function claimUnshielded(
+        ERC20ConfidentialStorage storage $,
+        bytes32 id,
+        uint64 decryptedAmount,
+        bytes calldata decryptionProof
+    ) public {
+        Claim memory claim = handleClaim(id, decryptedAmount, decryptionProof);
+
+        uint256 amountPublic = uint256(claim.decryptedAmount) * $._conversionRate;
+        IConfidentialLedger(address(this)).__ledger(CONFIDENTIAL_POOL, claim.to, amountPublic);
+
+        emit UnshieldedTokensClaimed(claim.to, id, FHE.wrapEuint64(claim.ctHash), claim.decryptedAmount);
+    }
+
+    function confidentialMint(ERC20ConfidentialStorage storage $, address to, uint64 amount) public {
+        IConfidentialLedger(address(this)).__ledger(address(0), CONFIDENTIAL_POOL, uint256(amount) * $._conversionRate);
+        update($, address(0), to, FHE.asEuint64(amount));
+    }
+
+    // =========================================================================
+    //  Confidential transfer surface (full orchestration; host wrappers are 1-liners)
+    // =========================================================================
+
+    function confTransfer(
+        ERC20ConfidentialStorage storage $,
+        address to,
+        euint64 value
+    ) public returns (euint64 transferred) {
+        if (!FHE.isAllowed(value, msg.sender))
+            revert ERC20ConfidentialUnauthorizedUseOfEncryptedAmount(value, msg.sender);
+        transferred = _move($, msg.sender, to, value);
+        FHE.allowTransient(transferred, msg.sender);
+    }
+
+    function confTransferIn(
+        ERC20ConfidentialStorage storage $,
+        address to,
+        InEuint64 memory inValue
+    ) public returns (euint64 transferred) {
+        transferred = _move($, msg.sender, to, FHE.asEuint64(inValue));
+        FHE.allowTransient(transferred, msg.sender);
+    }
+
+    function confTransferFrom(
+        ERC20ConfidentialStorage storage $,
+        address from,
+        address to,
+        euint64 value
+    ) public returns (euint64 transferred) {
+        if (!FHE.isAllowed(value, msg.sender))
+            revert ERC20ConfidentialUnauthorizedUseOfEncryptedAmount(value, msg.sender);
+        if (!_isOperator($, from, msg.sender)) revert ERC20ConfidentialUnauthorizedSpender(from, msg.sender);
+        transferred = _move($, from, to, value);
+        FHE.allowTransient(transferred, msg.sender);
+    }
+
+    function confTransferFromIn(
+        ERC20ConfidentialStorage storage $,
+        address from,
+        address to,
+        InEuint64 memory inValue
+    ) public returns (euint64 transferred) {
+        if (!_isOperator($, from, msg.sender)) revert ERC20ConfidentialUnauthorizedSpender(from, msg.sender);
+        transferred = _move($, from, to, FHE.asEuint64(inValue));
+        FHE.allowTransient(transferred, msg.sender);
+    }
+
+    function confTransferAndCall(
+        ERC20ConfidentialStorage storage $,
+        address to,
+        euint64 amount,
+        bytes calldata data
+    ) public returns (euint64 transferred) {
+        if (!FHE.isAllowed(amount, msg.sender))
+            revert ERC20ConfidentialUnauthorizedUseOfEncryptedAmount(amount, msg.sender);
+        transferred = _moveAndCall($, msg.sender, to, amount, data);
+        FHE.allowTransient(transferred, msg.sender);
+    }
+
+    function confTransferAndCallIn(
+        ERC20ConfidentialStorage storage $,
+        address to,
+        InEuint64 memory inAmount,
+        bytes calldata data
+    ) public returns (euint64 transferred) {
+        transferred = _moveAndCall($, msg.sender, to, FHE.asEuint64(inAmount), data);
+        FHE.allowTransient(transferred, msg.sender);
+    }
+
+    function confTransferFromAndCall(
+        ERC20ConfidentialStorage storage $,
+        address from,
+        address to,
+        euint64 amount,
+        bytes calldata data
+    ) public returns (euint64 transferred) {
+        if (!FHE.isAllowed(amount, msg.sender))
+            revert ERC20ConfidentialUnauthorizedUseOfEncryptedAmount(amount, msg.sender);
+        if (!_isOperator($, from, msg.sender)) revert ERC20ConfidentialUnauthorizedSpender(from, msg.sender);
+        transferred = _moveAndCall($, from, to, amount, data);
+        FHE.allowTransient(transferred, msg.sender);
+    }
+
+    function confTransferFromAndCallIn(
+        ERC20ConfidentialStorage storage $,
+        address from,
+        address to,
+        InEuint64 memory inAmount,
+        bytes calldata data
+    ) public returns (euint64 transferred) {
+        if (!_isOperator($, from, msg.sender)) revert ERC20ConfidentialUnauthorizedSpender(from, msg.sender);
+        transferred = _moveAndCall($, from, to, FHE.asEuint64(inAmount), data);
+        FHE.allowTransient(transferred, msg.sender);
+    }
+
+    function isOperator(
+        ERC20ConfidentialStorage storage $,
+        address holder,
+        address spender
+    ) public view returns (bool) {
+        return _isOperator($, holder, spender);
+    }
+
+    // =========================================================================
+    //  Internal helpers (inline within the library)
+    // =========================================================================
+
+    function _move(
+        ERC20ConfidentialStorage storage $,
+        address from,
+        address to,
+        euint64 value
+    ) internal returns (euint64) {
+        if (from == address(0)) revert ConfidentialInvalidSender(address(0));
+        if (to == address(0)) revert ConfidentialInvalidReceiver(address(0));
+        return update($, from, to, value);
+    }
+
+    function _moveAndCall(
+        ERC20ConfidentialStorage storage $,
+        address from,
+        address to,
+        euint64 amount,
+        bytes calldata data
+    ) internal returns (euint64 transferred) {
+        euint64 sent = _move($, from, to, amount);
+        ebool success = FHERC20Utils.checkOnTransferReceived(msg.sender, from, to, sent, data);
+        euint64 refund = update($, to, from, FHE.select(success, FHE.asEuint64(0), sent));
+        transferred = FHE.sub(sent, refund);
+    }
+
+    function _isOperator(
+        ERC20ConfidentialStorage storage $,
+        address holder,
+        address spender
+    ) internal view returns (bool) {
+        return holder == spender || block.timestamp <= $._operators[holder][spender];
+    }
+
+    // =========================================================================
+    //  Unshield-claim bookkeeping (relocated from FHERC20WrapperClaimHelper).
+    //  Uses its own ERC-7201 slot; the host delegates here so the (chunky)
+    //  EnumerableSet code lives in the library, not in the token.
+    // =========================================================================
+
+    using EnumerableSet for EnumerableSet.Bytes32Set;
+
+    struct Claim {
+        bytes32 id; // unique per-claimant key (NOT the ciphertext handle); how the claim is referenced
+        address to;
+        bytes32 ctHash; // the burned ciphertext handle; binds the decryption proof in handleClaim
+        uint64 requestedAmount;
+        uint64 decryptedAmount;
+        bool claimed;
+    }
+
+    /// @custom:storage-location erc7201:fherc20.storage.FHERC20WrapperClaimHelper
+    struct ClaimStorage {
+        mapping(bytes32 id => Claim) _claims; // keyed by claim id, NOT by the ciphertext handle
+        mapping(address => EnumerableSet.Bytes32Set) _userClaims; // holds claim ids
+        mapping(address => uint256) _claimNonce; // per-claimant counter for unique id derivation
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("fherc20.storage.FHERC20WrapperClaimHelper")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant CLAIM_SLOT = 0x90973842d0546f0dce9511f9a89cc80d5315812909eb805129843b5aeeaaae00;
+
+    error ClaimNotFound();
+    error AlreadyClaimed();
+
+    function _claimStore() private pure returns (ClaimStorage storage $) {
+        assembly {
+            $.slot := CLAIM_SLOT
+        }
+    }
+
+    /// @dev Records a pending unshield claim keyed by a UNIQUE per-claimant id, not by the
+    /// ciphertext handle. CoFHE handles are content-addressed (a pure function of the operation
+    /// lineage, with no per-caller or per-call salt), so two unshields of an identical
+    /// burned-amount lineage produce the SAME handle; keying claims by that handle would let a
+    /// second unshield overwrite the first claimant's record and redirect their payout. The
+    /// handle is retained as `ctHash` to bind the decryption proof in {handleClaim}.
+    function createClaim(address to, uint64 requestedAmount, euint64 claimable) public returns (bytes32 id) {
+        ClaimStorage storage $ = _claimStore();
+        bytes32 h = FHE.unwrap(claimable);
+        id = keccak256(abi.encode(to, $._claimNonce[to]++, h));
+        $._claims[id] = Claim({
+            id: id,
+            to: to,
+            ctHash: h,
+            requestedAmount: requestedAmount,
+            decryptedAmount: 0,
+            claimed: false
+        });
+        $._userClaims[to].add(id);
+    }
+
+    function handleClaim(
+        bytes32 id,
+        uint64 decryptedAmount,
+        bytes memory decryptionProof
+    ) public returns (Claim memory claim) {
+        ClaimStorage storage $ = _claimStore();
+        claim = $._claims[id];
+        if (claim.to == address(0)) revert ClaimNotFound();
+        if (claim.claimed) revert AlreadyClaimed();
+
+        // The proof binds `decryptedAmount` to the burned handle (`ctHash`), which is fixed at
+        // createClaim time — never to the caller-supplied `id`.
+        FHE.verifyDecryptResult(FHE.wrapEuint64(claim.ctHash), decryptedAmount, decryptionProof);
+
+        claim.decryptedAmount = decryptedAmount;
+        claim.claimed = true;
+        $._claims[id] = claim;
+        $._userClaims[claim.to].remove(id);
+    }
+
+    function getClaim(bytes32 id) public view returns (Claim memory) {
+        return _claimStore()._claims[id];
+    }
+
+    function getUserClaims(address user) public view returns (Claim[] memory userClaims) {
+        ClaimStorage storage $ = _claimStore();
+        bytes32[] memory ids = $._userClaims[user].values();
+        userClaims = new Claim[](ids.length);
+        for (uint256 i = 0; i < ids.length; i++) {
+            userClaims[i] = $._claims[ids[i]];
+        }
+    }
+}

--- a/contracts/interfaces/IERC20ConfidentialCore.sol
+++ b/contracts/interfaces/IERC20ConfidentialCore.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { euint64, InEuint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+
+/**
+ * @dev Confidential-only surface for {ERC20ConfidentialCoreUpgradeable}.
+ *
+ * Unlike {IERC20Confidential}, this interface deliberately does NOT inherit OpenZeppelin's
+ * `IERC20` / `IERC165` (nor `IERC7984` / `IFHERC20`). That keeps a contract which already brings
+ * its own public ERC-20 ledger and ERC-165 surface (e.g. an M0 extension) free of duplicate base
+ * types when it also mixes in the confidential layer. The public ERC-20 metadata/ledger and
+ * `supportsInterface` are expected to come from the host ledger.
+ */
+interface IERC20ConfidentialCore {
+    /// @dev Emitted when the expiration timestamp for an operator is updated for a holder.
+    event OperatorSet(address indexed holder, address indexed operator, uint48 until);
+
+    /// @dev Emitted when a confidential transfer is made of encrypted amount `amount`.
+    event ConfidentialTransfer(address indexed from, address indexed to, euint64 indexed amount);
+
+    /// @dev Emitted when tokens are shielded (public -> confidential).
+    event TokensShielded(address indexed account, uint256 amount);
+
+    /// @dev Emitted when an unshield request is created.
+    event TokensUnshielded(address indexed account, euint64 indexed amount);
+
+    /// @dev Emitted when an unshield request is claimed (public tokens transferred).
+    ///      `unshieldRequestId` is the unique claim id (as passed to {claimUnshielded}), not the
+    ///      ciphertext handle; `unshieldAmount` wraps the burned handle.
+    event UnshieldedTokensClaimed(
+        address indexed account,
+        bytes32 indexed unshieldRequestId,
+        euint64 indexed unshieldAmount,
+        uint64 unshieldAmountCleartext
+    );
+
+    function confidentialDecimals() external view returns (uint8);
+
+    function confidentialTotalSupply() external view returns (euint64);
+
+    function confidentialBalanceOf(address account) external view returns (euint64);
+
+    function isOperator(address holder, address spender) external view returns (bool);
+
+    function setOperator(address operator, uint48 until) external;
+
+    function shield(uint256 amount) external;
+
+    function unshield(uint64 amount) external returns (euint64);
+
+    function unshield(euint64 amount) external returns (euint64);
+
+    /// @param id The unique claim id from {getClaim}/{getUserClaims} (NOT the ciphertext handle).
+    function claimUnshielded(bytes32 id, uint64 decryptedAmount, bytes calldata decryptionProof) external;
+
+    /// @param ids The unique claim ids from {getClaim}/{getUserClaims} (NOT ciphertext handles).
+    function claimUnshieldedBatch(
+        bytes32[] calldata ids,
+        uint64[] calldata decryptedAmounts,
+        bytes[] calldata decryptionProofs
+    ) external;
+
+    function confidentialTransfer(address to, euint64 amount) external returns (euint64 transferred);
+
+    function confidentialTransfer(address to, InEuint64 memory encryptedAmount) external returns (euint64 transferred);
+
+    function confidentialTransferFrom(address from, address to, euint64 amount) external returns (euint64 transferred);
+
+    function confidentialTransferFrom(
+        address from,
+        address to,
+        InEuint64 memory encryptedAmount
+    ) external returns (euint64 transferred);
+}


### PR DESCRIPTION
## What

Adds a second way to build a dual-layer (public + confidential) token, for hosts that
**already bring their own ERC-20 ledger and OpenZeppelin stack** — where inheriting
`ERC20Confidential(Upgradeable)` is impossible (duplicate OZ bases in the inheritance
graph) or doesn't fit under EIP-170. Three new files, purely additive — no existing
file is modified:

| File | Role |
|---|---|
| `ERC20Confidential/ERC20ConfidentialCoreUpgradeable.sol` | OZ-base-free mixin carrying the full confidential layer |
| `ERC20Confidential/ERC20ConfidentialLib.sol` | external (linked, delegatecall'd) library holding the heavy FHE orchestration |
| `interfaces/IERC20ConfidentialCore.sol` | confidential-only interface (no OZ `IERC20`/`IERC165` inheritance) |

## Design

- **Three ledger hooks** (`_ledgerMint`, `_ledgerTransfer`, `_ledgerBalanceOf`) are all a
  host implements to wire the confidential layer onto its existing public ERC-20 — there is
  exactly ONE ledger, the host's.
- **EIP-170 split**: `public` library functions are delegatecall'd, so shield/unshield/claim
  and the 8-overload confidential-transfer surface live in the library's deployed bytecode,
  not in every token. Ledger ops reach back through a self-only `__ledger` bridge.
- **Single policy hook** `_beforeConfidentialMove` funnels every account-initiated
  confidential move (transfers + unshield) — one override implements freeze/pause.
- **Storage-portable**: same ERC-7201 slot (`fherc20.storage.ERC20Confidential`) as
  `ERC20ConfidentialUpgradeable`; the lib's struct only appends an `_observer` field.
- **Unique claim ids**: unshield claims are keyed by `keccak256(to, nonce++, handle)` rather
  than the ciphertext handle. CoFHE handles are content-addressed (no caller/call salt), so
  identical balance lineages produce identical handles — handle-keyed claims can overwrite
  each other and redirect payouts. The handle is kept as `ctHash` to bind the decryption proof.
  ⚠️ Note this means `claimUnshielded(bytes32 id, ...)` takes the **claim id** from
  `getClaim`/`getUserClaims`, not the ctHash (differs from the monolithic contracts).
- Includes `claimUnshieldedBatch` (same direction as #24) and an ERC-7984-style compliance
  observer (forward grants in `update()`, historical top-up via `grantPast`).

## Deployment notes

- `ERC20ConfidentialLib` is an external library: deploy once per chain and link
  (OZ upgrades plugin: `unsafeAllowLinkedLibraries: true`).
- The indicator token is optional and kept out of host bytecode — deploy it separately and
  wire via the host.

## Provenance & testing

- All dependencies (`ERC20ConfidentialIndicator`, `FHESafeMath`, `FHERC20Utils`, `IFHERC20`,
  `IERC7984*`) already exist in this repo, byte-identical — nothing else needed to travel.
- Compiles clean in this repo's toolchain (solc 0.8.25, OZ 5.4.0, cancun).
- Battle-tested in the fusd-jmi repo as the base of FhenixToken (the live FIX token), FUSDJmi
  (M0 JMI fusion at the EIP-170 ceiling) and ConfidentialERC4626Dual, including an external
  audit of that integration (claim-collision and cross-function-reentrancy findings are fixed
  in this code).

## Follow-ups (deliberately not in this PR)

1. **Security port**: the monolithic contracts + `FHERC20WrapperClaimHelper(Upgradeable)`
   still key claims by ctHash (collision-prone) and lack a reentrancy guard on confidential
   transfers — should be ported independently.
2. **Dedup**: the monoliths can be re-based as thin hosts over this lib (same storage slot);
   shared file-level events/errors/constants. Major-version change (library linking +
   claim-id ABI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
