### PR TITLE
docs: fix constructor examples (missing contractURI_, wrong wrapper contract name and import path)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ pragma solidity ^0.8.25;
 import { FHERC20 } from "fhenix-confidential-contracts/contracts/FHERC20.sol";
 
 contract MyConfidentialToken is FHERC20 {
-    constructor() FHERC20("My Confidential Token", "eMCT", 18) {
+    constructor() FHERC20("My Confidential Token", "eMCT", 18, "") {
         // Mint initial supply to deployer
         _mint(msg.sender, 1000000 * 10**18);
     }
@@ -66,7 +66,7 @@ import { FHERC20Permit } from "fhenix-confidential-contracts/contracts/FHERC20Pe
 
 contract MyPermitToken is FHERC20, FHERC20Permit {
     constructor()
-        FHERC20("My Permit Token", "eMPT", 18)
+        FHERC20("My Permit Token", "eMPT", 18, "")
         FHERC20Permit("My Permit Token")
     {
         _mint(msg.sender, 1000000 * 10**18);
@@ -80,12 +80,13 @@ contract MyPermitToken is FHERC20, FHERC20Permit {
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { FHERC20Wrapper } from "fhenix-confidential-contracts/contracts/FHERC20Wrapper.sol";
+import { FHERC20ERC20Wrapper } from "fhenix-confidential-contracts/contracts/FHERC20/extensions/FHERC20ERC20Wrapper.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-contract MyWrappedToken is FHERC20Wrapper {
+contract MyWrappedToken is FHERC20ERC20Wrapper {
     constructor(IERC20 underlyingToken)
-        FHERC20Wrapper(underlyingToken, "")
+        FHERC20ERC20Wrapper(underlyingToken)
+        FHERC20("My Wrapped Token", "eMWT", 18, "")
     {}
 }
 


### PR DESCRIPTION
## Summary

All three constructor examples in the README contain errors that prevent
compilation. This PR corrects them to match the current source code.

## Root Cause

The examples were written before `contractURI_` was added as a required
parameter to `FHERC20`'s constructor. They were never updated after that
change landed, so anyone following the README today will hit compile errors
immediately.

## Changes

### 1. Basic FHERC20 example — missing `contractURI_`

`FHERC20` constructor signature (FHERC20.sol:65):
```solidity
constructor(string memory name_, string memory symbol_, uint8 decimals_, string memory contractURI_)
```

The example passes 3 arguments; the fix adds the required 4th.

**Before:**
```solidity
constructor() FHERC20("My Confidential Token", "eMCT", 18) {
```
**After:**
```solidity
constructor() FHERC20("My Confidential Token", "eMCT", 18, "") {
```

### 2. Permit example — same missing `contractURI_`

**Before:**
```solidity
FHERC20("My Permit Token", "eMPT", 18)
```
**After:**
```solidity
FHERC20("My Permit Token", "eMPT", 18, "")
```

### 3. Wrapper example — three compounding errors

The wrapper example has three separate issues:
- Wrong contract name: `FHERC20Wrapper` → `FHERC20ERC20Wrapper`
- Wrong import path: `contracts/FHERC20Wrapper.sol` → `contracts/FHERC20/extensions/FHERC20ERC20Wrapper.sol`
- Missing explicit `FHERC20(...)` call: `FHERC20ERC20Wrapper` is abstract and
  inherits from `FHERC20`, so the derived contract must call the `FHERC20`
  constructor directly with all 4 arguments

**Before:**
```solidity
import "fhenix-confidential-contracts/contracts/FHERC20Wrapper.sol";

contract MyWrappedToken is FHERC20Wrapper {
    constructor(IERC20 underlyingToken)
        FHERC20Wrapper(underlyingToken, "")
    {}
}
```
**After:**
```solidity
import "fhenix-confidential-contracts/contracts/FHERC20/extensions/FHERC20ERC20Wrapper.sol";

contract MyWrappedToken is FHERC20ERC20Wrapper {
    constructor(IERC20 underlyingToken)
        FHERC20ERC20Wrapper(underlyingToken)
        FHERC20("My Wrapped Token", "eMWT", 18, "")
    {}
}
```

## Verification

Checked against:
- `contracts/FHERC20/FHERC20.sol:65` — constructor signature
- `contracts/FHERC20/extensions/FHERC20ERC20Wrapper.sol:32` — wrapper constructor and inheritance chain
- `contracts/FHERC20/FHERC20Upgradeable.sol` — `__FHERC20_init` NatSpec (itself correctly lists all 4 params)

No existing issue or PR covers these README errors (checked all 26 issues and 6 open PRs).