### PR TITLE
test(FHERC20): assert wrapper ERC-165 interfaceIds in supportsInterface

### DIFF
--- a/test/FHERC20.behavior.ts
+++ b/test/FHERC20.behavior.ts
@@ -73,6 +73,29 @@ export function getIFHERC20InterfaceId(): string {
   return computeInterfaceId(["balanceOfIsIndicator()", "indicatorTick()"]);
 }
 
+export function getIFHERC20ERC20WrapperInterfaceId(): string {
+  return computeInterfaceId([
+    "shield(address,uint256)",
+    "unshield(address,address,uint64)",
+    "unshield(address,address,bytes32)",
+    "claimUnshielded(bytes32,uint64,bytes)",
+    "rate()",
+    "underlying()",
+  ]);
+}
+
+export function getIFHERC20NativeWrapperInterfaceId(): string {
+  return computeInterfaceId([
+    "shieldWrappedNative(address,uint256)",
+    "shieldNative(address)",
+    "unshield(address,address,uint64)",
+    "unshield(address,address,bytes32)",
+    "claimUnshielded(bytes32,uint64,bytes)",
+    "rate()",
+    "weth()",
+  ]);
+}
+
 // =========================================================================
 //  Shared behavior suites
 // =========================================================================

--- a/test/FHERC20ERC20Wrapper.test.ts
+++ b/test/FHERC20ERC20Wrapper.test.ts
@@ -8,6 +8,7 @@ import {
   prepExpectFHERC20BalancesChange,
 } from "./utils";
 import { ZeroAddress, ContractTransactionResponse } from "ethers";
+import { getIFHERC20ERC20WrapperInterfaceId } from "./FHERC20.behavior";
 
 async function getUnshieldRequestId(
   tx: ContractTransactionResponse,
@@ -77,6 +78,8 @@ describe("FHERC20ERC20Wrapper", function () {
 
       // ERC165
       expect(await eBTC.supportsInterface("0x01ffc9a7")).to.equal(true);
+      // IFHERC20ERC20Wrapper
+      expect(await eBTC.supportsInterface(getIFHERC20ERC20WrapperInterfaceId())).to.equal(true);
       // IERC1363Receiver
       expect(await eBTC.supportsInterface("0x88a7ca5c")).to.equal(true);
       // Random unsupported

--- a/test/FHERC20NativeWrapper.test.ts
+++ b/test/FHERC20NativeWrapper.test.ts
@@ -3,6 +3,7 @@ import hre, { ethers } from "hardhat";
 import { FHERC20NativeWrapper_Harness, WETH_Harness } from "../typechain-types";
 import { expectFHERC20BalancesChange, prepExpectFHERC20BalancesChange } from "./utils";
 import { ZeroAddress, ContractTransactionResponse } from "ethers";
+import { getIFHERC20NativeWrapperInterfaceId } from "./FHERC20.behavior";
 
 async function getUnshieldRequestId(
   tx: ContractTransactionResponse,
@@ -72,6 +73,8 @@ describe("FHERC20NativeWrapper", function () {
 
       // ERC165
       expect(await eETH.supportsInterface("0x01ffc9a7")).to.equal(true);
+      // IFHERC20NativeWrapper
+      expect(await eETH.supportsInterface(getIFHERC20NativeWrapperInterfaceId())).to.equal(true);
       // Random unsupported
       expect(await eETH.supportsInterface("0xdeadbeef")).to.equal(false);
     });


### PR DESCRIPTION
## Problem

Neither wrapper test suite asserts the interfaceId of the interface the contract exists to implement:

| Suite | Asserted today | Missing |
| --- | --- | --- |
| [`FHERC20ERC20Wrapper.test.ts:75`](test/FHERC20ERC20Wrapper.test.ts#L75) | ERC165 `0x01ffc9a7`, IERC1363Receiver `0x88a7ca5c` | `type(IFHERC20ERC20Wrapper).interfaceId` |
| [`FHERC20NativeWrapper.test.ts:70`](test/FHERC20NativeWrapper.test.ts#L70) | ERC165 `0x01ffc9a7` only | `type(IFHERC20NativeWrapper).interfaceId` |

`FHERC20.behavior.ts` already does this properly — it derives ids from selectors via `computeInterfaceId` and asserts `IERC7984`, `IFHERC20` and `IERC20`. The two wrapper suites just never got the same treatment for their own primary interface.

**This gap already cost you a silent break.** `b658403` ("adds new unshield with encrypted input", 2026-04-10) added the `unshield(address,address,euint64)` overload to both wrapper interfaces. Adding a function to an interface changes its ERC-165 id, so both ids moved — after `v0.3.1` was published on 2026-04-01:

| Interface | v0.3.1 (pre-`b658403`) | current `master` |
| --- | --- | --- |
| `IFHERC20ERC20Wrapper` | `0x4d52d826` | **`0x216f1651`** |
| `IFHERC20NativeWrapper` | `0xaefc9bc7` | **`0xc2c155b0`** |

No test noticed, because no test looks at those ids.

ERC-165 ids are exactly how off-chain consumers detect token type, so a silent id change is a silent break. `@cofhe/react` still hardcodes the pre-`b658403` values for both wrapper types in `packages/react/src/constants/tokenTypeConfig.ts` (`wrappedErc20: ['0x4d52d826']`, `wrappedNative: ['0xaefc9bc7']`), which its `detectSupportedTokenTypeFromInterfaces` probe compares against `supportsInterface`. Notably `dual: ['0xbe4d657f']` **is** still correct — `IERC20Confidential` happens to compute to that today — which is what makes the two wrapper entries easy to miss.

To be clear about scope: this PR does not change any interface or contract, and does not touch the SDK. It only makes the ids asserted, so the next change to a wrapper interface shows up as a failing test rather than as a silently stale constant downstream.

## Change

- Adds `getIFHERC20ERC20WrapperInterfaceId()` and `getIFHERC20NativeWrapperInterfaceId()` to `test/FHERC20.behavior.ts`, next to the existing `getIERC7984InterfaceId` / `getIFHERC20InterfaceId` / `getIERC20InterfaceId`.
- Asserts each in its suite's existing "should support expected interfaces" test.

Ids are derived from the selector list through the existing `computeInterfaceId` helper rather than hardcoded, so the assertions track the interfaces automatically. Test-only, purely additive (+29/-0), no changeset since nothing user-facing changes.

The existing `0x88a7ca5c` assertion is left as-is — it really is `IERC1363Receiver`, matching its comment (verified: `onTransferReceived(address,address,uint256,bytes)` → `0x88a7ca5c`, a single-function interface).

## Verification

I could not run `pnpm test` locally: Hardhat's native EDR binary is blocked by an Application Control policy on this machine (`ERR_DLOPEN_FAILED` loading `edr.win32-x64-msvc.node`). `hardhat compile` works fine — all 87 sources compile. So instead of asserting "tests pass", here is what I did verify, and how:

**1. The expected ids are correct.** Compiled the interfaces with solc and XOR'd the `functionSelector` values of the functions declared directly in each interface (which is exactly how Solidity defines `type(I).interfaceId` — inherited functions excluded). Validated the method against two publicly known values first:

```
IERC20   computed=0x36372b07  expected=0x36372b07  MATCH
IERC165  computed=0x01ffc9a7  expected=0x01ffc9a7  MATCH
```

then:

```
IFHERC20ERC20Wrapper   0x216f1651   (6 fns)
IFHERC20NativeWrapper  0xc2c155b0   (7 fns)
IERC20Confidential     0xbe4d657f   (5 fns)
```

**2. The TypeScript selector lists I added reproduce those ids.** Ran the repo's own `computeInterfaceId` over my lists and compared per selector against solc's AST output — all 9 selectors matched, and both ids matched (`0x216f1651`, `0xc2c155b0`). So the helpers agree with the compiler, not just with me.

**3. The assertions must therefore hold.** `FHERC20ERC20Wrapper.supportsInterface` returns true for `type(IFHERC20ERC20Wrapper).interfaceId` ([line 150](contracts/FHERC20/extensions/FHERC20ERC20Wrapper.sol#L150)), `FHERC20NativeWrapper` likewise ([line 172](contracts/FHERC20/extensions/FHERC20NativeWrapper.sol#L172)), and neither `FHERC20ERC20Wrapper_Harness` nor `FHERC20NativeWrapper_Harness` overrides `supportsInterface` — they only inherit.

**4. No type or lint regression.** `tsc --noEmit` reports the same 10 error lines before and after my change, none of them in the files I touched (they are a local pnpm duplicate-`viem` artifact, `2.38.6` vs `2.55.13`). `eslint` reports 0 errors. `prettier --check` on the LF-normalised blobs passes on `FHERC20.behavior.ts`; the two `.test.ts` files fail it both before and after my change, on pre-existing long `unshield(...)` lines I did not touch — I left those alone rather than bury this diff in reformatting.

CI running `pnpm test` is still the authoritative check on the assertions themselves.

Happy to split this differently, or to open an issue first for the wider "wrapper interfaceIds drifted from the published release" question if you'd rather track that separately — `CONTRIBUTING.md` asks for an issue on non-trivial changes, and I judged a purely additive test to be on the trivial side, but say the word.
