### PR TITLE
test(FHERC20): cover self-transfer and zero-value confidentialTransfer balances

### DIFF
--- a/test/FHERC20.behavior.ts
+++ b/test/FHERC20.behavior.ts
@@ -213,6 +213,72 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
       await expectFHERC20BalancesChange(token, bob.address, 0n);
       await expectFHERC20BalancesChange(token, alice.address, 0n);
     });
+
+    it("should leave balance unchanged after a partial self-transfer", async function () {
+      const { token, bob, bobClient } = await setupFixture();
+
+      const mintValue = 10_000_000n;
+      await token.mint(bob.address, mintValue);
+
+      const transferValue = 1_000_000n;
+      const [encTransferInput] = await bobClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+
+      await prepExpectFHERC20BalancesChange(token, bob.address);
+
+      await expect(
+        token
+          .connect(bob)
+          ["confidentialTransfer(address,(uint256,uint8,uint8,bytes))"](bob.address, encTransferInput),
+      ).to.emit(token, "ConfidentialTransfer");
+
+      await expectFHERC20BalancesChange(token, bob.address, 0n);
+    });
+
+    it("should leave balance unchanged after a full-balance self-transfer", async function () {
+      const { token, bob, bobClient } = await setupFixture();
+
+      const mintValue = 10_000_000n;
+      await token.mint(bob.address, mintValue);
+
+      const [encTransferInput] = await bobClient.encryptInputs([Encryptable.uint64(mintValue)]).execute();
+
+      await prepExpectFHERC20BalancesChange(token, bob.address);
+
+      await expect(
+        token
+          .connect(bob)
+          ["confidentialTransfer(address,(uint256,uint8,uint8,bytes))"](bob.address, encTransferInput),
+      ).to.emit(token, "ConfidentialTransfer");
+
+      await expectFHERC20BalancesChange(token, bob.address, 0n);
+    });
+
+    it("should leave both balances unchanged after a zero-value transfer", async function () {
+      const { token, bob, alice, bobClient } = await setupFixture();
+
+      const mintValue = 10_000_000n;
+      await token.mint(bob.address, mintValue);
+      await token.mint(alice.address, mintValue);
+
+      const [encTransferInput] = await bobClient.encryptInputs([Encryptable.uint64(0n)]).execute();
+
+      await prepExpectFHERC20BalancesChange(token, bob.address);
+      await prepExpectFHERC20BalancesChange(token, alice.address);
+
+      // NOTE: a 0-value transfer still ticks both parties' ERC-20 indicator counters -
+      // FHERC20.sol:_update increments/decrements _indicatedBalances unconditionally
+      // whenever from/to are non-zero addresses, regardless of the transferred amount.
+      // This test only asserts the *confidential* balance is unchanged; it does not
+      // assert on balanceOf()/indicatorTick(), which do move even though no value moved.
+      await expect(
+        token
+          .connect(bob)
+          ["confidentialTransfer(address,(uint256,uint8,uint8,bytes))"](alice.address, encTransferInput),
+      ).to.emit(token, "ConfidentialTransfer");
+
+      await expectFHERC20BalancesChange(token, bob.address, 0n);
+      await expectFHERC20BalancesChange(token, alice.address, 0n);
+    });
   });
 
   describe("operator management", function () {


### PR DESCRIPTION
## What

Adds three test cases to the `confidentialTransfer` suite in
`test/FHERC20.behavior.ts`:

- partial self-transfer (`from == to`) leaves the sender's balance unchanged
- full-balance self-transfer leaves the sender's balance unchanged
- zero-value transfer leaves both parties' balances unchanged

No production code is changed. Tests only.

## Why

`_update` is safe for the `from == to` case because it writes
`_balances[from]` before it reads `_balances[to]`, so a self-transfer reads
the already-decremented balance and adds the amount back, netting to zero. That
safety depends on statement ordering within `_update` and nothing currently
asserts it. These tests lock the invariant so a future refactor of the transfer
path can't silently reintroduce a self-transfer balance inflation without a
failing test.

The zero-value case similarly has no existing coverage. Note that a zero-value
transfer still ticks the ERC-20 indicator counters (`_update` updates
`_indicatedBalances` unconditionally for non-zero addresses); these tests assert
only that the confidential balance is unchanged and deliberately do not assert on
the indicator, to avoid pinning behavior that isn't the subject of this change.

## Testing

`pnpm install && npx hardhat test test/FHERC20.test.ts --network hardhat`

52 pre-existing tests still pass; 55 total with the 3 added. No changes to
existing tests.