### PR TITLE
fix(FHESafeMath): short-circuit trySub when `a` is uninitialized

### DIFF
--- a/contracts/utils/FHESafeMath.sol
+++ b/contracts/utils/FHESafeMath.sol
@@ -63,6 +63,12 @@ library FHESafeMath {
      * will be `a - b`. Otherwise, `success` will be false, and `res` will be 0.
      */
     function trySub(euint64 a, euint64 b) internal returns (ebool success, euint64 res) {
+        if (!FHE.isInitialized(a)) {
+            if (!FHE.isInitialized(b)) {
+                return (FHE.asEbool(true), a);
+            }
+            return (FHE.eq(b, FHE.asEuint64(0)), FHE.asEuint64(0));
+        }
         if (!FHE.isInitialized(b)) {
             return (FHE.asEbool(true), a);
         }


### PR DESCRIPTION
trySub only short-circuited on an uninitialized `b`, unlike its sibling tryDecrease which handles both operands. Functionally equivalent (FHE.sub/FHE.lte already substitute 0 for an uninitialized value internally), but this adds the missing fast path for consistency with tryDecrease and to avoid unnecessary FHE ops when `a` is uninitialized.