### PR TITLE
feat: migrate to cofhe 0.7 batch input verification

### DIFF
--- a/.changeset/proud-inputs-verify.md
+++ b/.changeset/proud-inputs-verify.md
@@ -1,0 +1,17 @@
+---
+"fhenix-confidential-contracts": major
+---
+
+Migrate to `@cofhe/*` 0.7 and `@fhenixprotocol/cofhe-contracts` 0.2.x (batch input verification).
+
+`cofhe-contracts` 0.2.x deletes the `InEuintXX` structs and the `FHE.asEuint64(InEuint64)` overload. The per-ciphertext signature that the struct used to carry is replaced by one signature per batch, passed as a trailing `bytes` parameter.
+
+Breaking changes:
+
+- **Every function taking an encrypted input changed shape.** `InEuint64 memory encryptedAmount` becomes `externalEuint64 encryptedAmount, bytes calldata inputProof`, across `IERC7984`, `IERC20ConfidentialCore`, `FHERC20Core`, `ERC20ConfidentialCoreUpgradeable` and `ERC20ConfidentialLib`. On the wire the struct tuple `(uint256,uint8,uint8,bytes)` becomes `bytes32,bytes`, so callers selecting overloads by signature string must be updated.
+- **On the `*AndCall` overloads the proof is the LAST parameter**, after `bytes data`: `confidentialTransferAndCall(address,bytes32,bytes,bytes)`. `@cofhe/abi` requires a plain `bytes` in the final slot for the batch signature, and rejects the ABI otherwise.
+- **`ERC20ConfidentialLib` must be redeployed and every host relinked.** Its ABI changed, so this build is not interchangeable with library instances deployed before 0.7.
+- **Callers must name the consuming contract before encrypting.** `client.encryptInputs([...])` now requires `.setConsumingContract(address)` before `.execute()`, and `execute()` returns `[...hashes, signature]` rather than one struct per value. The verifier binds the consuming contract into the signed digest, so a batch signed for one contract cannot be replayed into another.
+- **`@fhenixprotocol/cofhe-contracts` is pinned to `0.2.0-beta.3`** and the `@cofhe/*` packages to a dated alpha, because 0.7.0 is not yet on the registry. Confirm the final versions before publishing this package.
+
+Not included: the move onto the `sharedEuintXX` types for encrypted values crossing a contract boundary. That changes `IERC7984Receiver`, which third parties implement, and both sides of a handoff must migrate together. The old spelling still compiles and runs, so it is tracked separately.

--- a/contracts/ERC20Confidential/ERC20ConfidentialCoreUpgradeable.sol
+++ b/contracts/ERC20Confidential/ERC20ConfidentialCoreUpgradeable.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { FHE, euint64, InEuint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+import { FHE, euint64, externalEuint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
 import { IERC20ConfidentialCore } from "../interfaces/IERC20ConfidentialCore.sol";
 import { ERC20ConfidentialIndicator } from "./ERC20ConfidentialIndicator.sol";
 import { ERC20ConfidentialLib } from "./ERC20ConfidentialLib.sol";
@@ -264,9 +264,13 @@ abstract contract ERC20ConfidentialCoreUpgradeable is IERC20ConfidentialCore, Re
         return ERC20ConfidentialLib.confTransfer(to, value);
     }
 
-    function confidentialTransfer(address to, InEuint64 memory inValue) public virtual nonReentrant returns (euint64) {
+    function confidentialTransfer(
+        address to,
+        externalEuint64 inValue,
+        bytes calldata inputProof
+    ) public virtual nonReentrant returns (euint64) {
         _beforeConfidentialMove(msg.sender, to);
-        return ERC20ConfidentialLib.confTransferIn(to, inValue);
+        return ERC20ConfidentialLib.confTransferIn(to, inValue, inputProof);
     }
 
     function confidentialTransferFrom(
@@ -281,10 +285,11 @@ abstract contract ERC20ConfidentialCoreUpgradeable is IERC20ConfidentialCore, Re
     function confidentialTransferFrom(
         address from,
         address to,
-        InEuint64 memory inValue
+        externalEuint64 inValue,
+        bytes calldata inputProof
     ) public virtual nonReentrant returns (euint64) {
         _beforeConfidentialMove(from, to);
-        return ERC20ConfidentialLib.confTransferFromIn(from, to, inValue);
+        return ERC20ConfidentialLib.confTransferFromIn(from, to, inValue, inputProof);
     }
 
     function confidentialTransferAndCall(
@@ -298,11 +303,12 @@ abstract contract ERC20ConfidentialCoreUpgradeable is IERC20ConfidentialCore, Re
 
     function confidentialTransferAndCall(
         address to,
-        InEuint64 memory encryptedAmount,
-        bytes calldata data
+        externalEuint64 encryptedAmount,
+        bytes calldata data,
+        bytes calldata inputProof
     ) public virtual nonReentrant returns (euint64) {
         _beforeConfidentialMove(msg.sender, to);
-        return ERC20ConfidentialLib.confTransferAndCallIn(to, encryptedAmount, data);
+        return ERC20ConfidentialLib.confTransferAndCallIn(to, encryptedAmount, data, inputProof);
     }
 
     function confidentialTransferFromAndCall(
@@ -318,11 +324,12 @@ abstract contract ERC20ConfidentialCoreUpgradeable is IERC20ConfidentialCore, Re
     function confidentialTransferFromAndCall(
         address from,
         address to,
-        InEuint64 memory encryptedAmount,
-        bytes calldata data
+        externalEuint64 encryptedAmount,
+        bytes calldata data,
+        bytes calldata inputProof
     ) public virtual nonReentrant returns (euint64) {
         _beforeConfidentialMove(from, to);
-        return ERC20ConfidentialLib.confTransferFromAndCallIn(from, to, encryptedAmount, data);
+        return ERC20ConfidentialLib.confTransferFromAndCallIn(from, to, encryptedAmount, data, inputProof);
     }
 
     // =========================================================================

--- a/contracts/ERC20Confidential/ERC20ConfidentialLib.sol
+++ b/contracts/ERC20Confidential/ERC20ConfidentialLib.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { FHE, euint64, InEuint64, ebool } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+import { FHE, euint64, externalEuint64, ebool } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { FHESafeMath } from "../utils/FHESafeMath.sol";
@@ -273,11 +273,7 @@ library ERC20ConfidentialLib {
         return unshield(amount);
     }
 
-    function claimUnshielded(
-        bytes32 id,
-        uint64 decryptedAmount,
-        bytes calldata decryptionProof
-    ) public {
+    function claimUnshielded(bytes32 id, uint64 decryptedAmount, bytes calldata decryptionProof) public {
         ERC20ConfidentialStorage storage $ = _getERC20ConfidentialStorage();
         Claim memory claim = handleClaim(id, decryptedAmount, decryptionProof);
 
@@ -338,16 +334,16 @@ library ERC20ConfidentialLib {
         FHE.allowTransient(transferred, msg.sender);
     }
 
-    function confTransferIn(address to, InEuint64 memory inValue) public returns (euint64 transferred) {
-        transferred = _move(msg.sender, to, FHE.asEuint64(inValue));
+    function confTransferIn(
+        address to,
+        externalEuint64 inValue,
+        bytes memory inputProof
+    ) public returns (euint64 transferred) {
+        transferred = _move(msg.sender, to, FHE.asEuint64(inValue, inputProof));
         FHE.allowTransient(transferred, msg.sender);
     }
 
-    function confTransferFrom(
-        address from,
-        address to,
-        euint64 value
-    ) public returns (euint64 transferred) {
+    function confTransferFrom(address from, address to, euint64 value) public returns (euint64 transferred) {
         if (!FHE.isAllowed(value, msg.sender))
             revert ERC20ConfidentialUnauthorizedUseOfEncryptedAmount(value, msg.sender);
         if (!_isOperator(from, msg.sender)) revert ERC20ConfidentialUnauthorizedSpender(from, msg.sender);
@@ -358,18 +354,15 @@ library ERC20ConfidentialLib {
     function confTransferFromIn(
         address from,
         address to,
-        InEuint64 memory inValue
+        externalEuint64 inValue,
+        bytes memory inputProof
     ) public returns (euint64 transferred) {
         if (!_isOperator(from, msg.sender)) revert ERC20ConfidentialUnauthorizedSpender(from, msg.sender);
-        transferred = _move(from, to, FHE.asEuint64(inValue));
+        transferred = _move(from, to, FHE.asEuint64(inValue, inputProof));
         FHE.allowTransient(transferred, msg.sender);
     }
 
-    function confTransferAndCall(
-        address to,
-        euint64 amount,
-        bytes calldata data
-    ) public returns (euint64 transferred) {
+    function confTransferAndCall(address to, euint64 amount, bytes calldata data) public returns (euint64 transferred) {
         if (!FHE.isAllowed(amount, msg.sender))
             revert ERC20ConfidentialUnauthorizedUseOfEncryptedAmount(amount, msg.sender);
         transferred = _moveAndCall(msg.sender, to, amount, data);
@@ -378,10 +371,11 @@ library ERC20ConfidentialLib {
 
     function confTransferAndCallIn(
         address to,
-        InEuint64 memory inAmount,
-        bytes calldata data
+        externalEuint64 inAmount,
+        bytes calldata data,
+        bytes memory inputProof
     ) public returns (euint64 transferred) {
-        transferred = _moveAndCall(msg.sender, to, FHE.asEuint64(inAmount), data);
+        transferred = _moveAndCall(msg.sender, to, FHE.asEuint64(inAmount, inputProof), data);
         FHE.allowTransient(transferred, msg.sender);
     }
 
@@ -401,11 +395,12 @@ library ERC20ConfidentialLib {
     function confTransferFromAndCallIn(
         address from,
         address to,
-        InEuint64 memory inAmount,
-        bytes calldata data
+        externalEuint64 inAmount,
+        bytes calldata data,
+        bytes memory inputProof
     ) public returns (euint64 transferred) {
         if (!_isOperator(from, msg.sender)) revert ERC20ConfidentialUnauthorizedSpender(from, msg.sender);
-        transferred = _moveAndCall(from, to, FHE.asEuint64(inAmount), data);
+        transferred = _moveAndCall(from, to, FHE.asEuint64(inAmount, inputProof), data);
         FHE.allowTransient(transferred, msg.sender);
     }
 

--- a/contracts/FHERC20/FHERC20Core.sol
+++ b/contracts/FHERC20/FHERC20Core.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { FHE, euint64, InEuint64, ebool } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+import { FHE, euint64, externalEuint64, ebool } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
 import { ReentrancyGuardTransient } from "@openzeppelin/contracts/utils/ReentrancyGuardTransient.sol";
 
 import { IFHERC20, IERC7984 } from "../interfaces/IFHERC20.sol";
@@ -193,9 +193,10 @@ abstract contract FHERC20Core is IFHERC20, ReentrancyGuardTransient {
     /// @inheritdoc IERC7984
     function confidentialTransfer(
         address to,
-        InEuint64 memory encryptedAmount
+        externalEuint64 encryptedAmount,
+        bytes calldata inputProof
     ) public virtual nonReentrant returns (euint64) {
-        return _transfer(msg.sender, to, FHE.asEuint64(encryptedAmount));
+        return _transfer(msg.sender, to, FHE.asEuint64(encryptedAmount, inputProof));
     }
 
     /// @inheritdoc IERC7984
@@ -208,10 +209,11 @@ abstract contract FHERC20Core is IFHERC20, ReentrancyGuardTransient {
     function confidentialTransferFrom(
         address from,
         address to,
-        InEuint64 memory encryptedAmount
+        externalEuint64 encryptedAmount,
+        bytes calldata inputProof
     ) public virtual nonReentrant returns (euint64 transferred) {
         if (!isOperator(from, msg.sender)) revert FHERC20UnauthorizedSpender(from, msg.sender);
-        transferred = _transfer(from, to, FHE.asEuint64(encryptedAmount));
+        transferred = _transfer(from, to, FHE.asEuint64(encryptedAmount, inputProof));
         FHE.allowTransient(transferred, msg.sender);
     }
 
@@ -230,10 +232,11 @@ abstract contract FHERC20Core is IFHERC20, ReentrancyGuardTransient {
     /// @inheritdoc IERC7984
     function confidentialTransferAndCall(
         address to,
-        InEuint64 memory encryptedAmount,
-        bytes calldata data
+        externalEuint64 encryptedAmount,
+        bytes calldata data,
+        bytes calldata inputProof
     ) public virtual nonReentrant returns (euint64 transferred) {
-        transferred = _transferAndCall(msg.sender, to, FHE.asEuint64(encryptedAmount), data);
+        transferred = _transferAndCall(msg.sender, to, FHE.asEuint64(encryptedAmount, inputProof), data);
         FHE.allowTransient(transferred, msg.sender);
     }
 
@@ -252,11 +255,12 @@ abstract contract FHERC20Core is IFHERC20, ReentrancyGuardTransient {
     function confidentialTransferFromAndCall(
         address from,
         address to,
-        InEuint64 memory encryptedAmount,
-        bytes calldata data
+        externalEuint64 encryptedAmount,
+        bytes calldata data,
+        bytes calldata inputProof
     ) public virtual nonReentrant returns (euint64 transferred) {
         if (!isOperator(from, msg.sender)) revert FHERC20UnauthorizedSpender(from, msg.sender);
-        transferred = _transferAndCall(from, to, FHE.asEuint64(encryptedAmount), data);
+        transferred = _transferAndCall(from, to, FHE.asEuint64(encryptedAmount, inputProof), data);
         FHE.allowTransient(transferred, msg.sender);
     }
 

--- a/contracts/interfaces/IERC20ConfidentialCore.sol
+++ b/contracts/interfaces/IERC20ConfidentialCore.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { euint64, InEuint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+import { euint64, externalEuint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
 
 /**
  * @dev Confidential-only surface for {ERC20ConfidentialCoreUpgradeable}.
@@ -68,13 +68,18 @@ interface IERC20ConfidentialCore {
 
     function confidentialTransfer(address to, euint64 amount) external returns (euint64 transferred);
 
-    function confidentialTransfer(address to, InEuint64 memory encryptedAmount) external returns (euint64 transferred);
+    function confidentialTransfer(
+        address to,
+        externalEuint64 encryptedAmount,
+        bytes calldata inputProof
+    ) external returns (euint64 transferred);
 
     function confidentialTransferFrom(address from, address to, euint64 amount) external returns (euint64 transferred);
 
     function confidentialTransferFrom(
         address from,
         address to,
-        InEuint64 memory encryptedAmount
+        externalEuint64 encryptedAmount,
+        bytes calldata inputProof
     ) external returns (euint64 transferred);
 }

--- a/contracts/interfaces/IERC7984.sol
+++ b/contracts/interfaces/IERC7984.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { euint64, InEuint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+import { euint64, externalEuint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
 import { IERC165 } from "@openzeppelin/contracts/interfaces/IERC165.sol";
 
 /**
@@ -58,10 +58,14 @@ interface IERC7984 is IERC165 {
      *
      * Returns the encrypted amount that was actually transferred.
      */
-    function confidentialTransfer(address to, InEuint64 memory encryptedAmount) external returns (euint64);
+    function confidentialTransfer(
+        address to,
+        externalEuint64 encryptedAmount,
+        bytes calldata inputProof
+    ) external returns (euint64);
 
     /**
-     * @dev Similar to {confidentialTransfer-address-InEuint64} but without an input proof.
+     * @dev Similar to {confidentialTransfer-address-externalEuint64} but without an input proof.
      *  The caller *must* already be allowed by ACL for the given `amount`.
      */
     function confidentialTransfer(address to, euint64 amount) external returns (euint64 transferred);
@@ -75,17 +79,18 @@ interface IERC7984 is IERC165 {
     function confidentialTransferFrom(
         address from,
         address to,
-        InEuint64 memory encryptedAmount
+        externalEuint64 encryptedAmount,
+        bytes calldata inputProof
     ) external returns (euint64);
 
     /**
-     * @dev Similar to {confidentialTransferFrom-address-address-InEuint64} but without an input proof.
+     * @dev Similar to {confidentialTransferFrom-address-address-externalEuint64} but without an input proof.
      * The caller *must* be already allowed by ACL for the given `amount`.
      */
     function confidentialTransferFrom(address from, address to, euint64 amount) external returns (euint64 transferred);
 
     /**
-     * @dev Similar to {confidentialTransfer-address-InEuint64} but with a callback to `to` after
+     * @dev Similar to {confidentialTransfer-address-externalEuint64} but with a callback to `to` after
      * the transfer.
      *
      * The callback is made to the {IERC7984Receiver-onConfidentialTransferReceived} function on the
@@ -94,8 +99,9 @@ interface IERC7984 is IERC165 {
      */
     function confidentialTransferAndCall(
         address to,
-        InEuint64 memory encryptedAmount,
-        bytes calldata data
+        externalEuint64 encryptedAmount,
+        bytes calldata data,
+        bytes calldata inputProof
     ) external returns (euint64 transferred);
 
     /// @dev Similar to {confidentialTransfer-address-euint64} but with a callback to `to` after the transfer.
@@ -106,14 +112,15 @@ interface IERC7984 is IERC165 {
     ) external returns (euint64 transferred);
 
     /**
-     * @dev Similar to {confidentialTransferFrom-address-address-InEuint64} but with a callback to `to`
+     * @dev Similar to {confidentialTransferFrom-address-address-externalEuint64} but with a callback to `to`
      * after the transfer.
      */
     function confidentialTransferFromAndCall(
         address from,
         address to,
-        InEuint64 memory encryptedAmount,
-        bytes calldata data
+        externalEuint64 encryptedAmount,
+        bytes calldata data,
+        bytes calldata inputProof
     ) external returns (euint64 transferred);
 
     /**

--- a/contracts/interfaces/IFHERC20.sol
+++ b/contracts/interfaces/IFHERC20.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { euint64, InEuint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+import { euint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IERC7984 } from "./IERC7984.sol";
 

--- a/contracts/test/MockFherc20Vault.sol
+++ b/contracts/test/MockFherc20Vault.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { FHE, InEuint64, euint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+import { FHE, externalEuint64, euint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
 import { FHERC20 } from "../FHERC20/FHERC20.sol";
 import { FHESafeMath } from "../utils/FHESafeMath.sol";
 
@@ -14,8 +14,8 @@ contract MockFHERC20Vault {
         asset = FHERC20(_asset);
     }
 
-    function deposit(InEuint64 calldata inAmount) external {
-        euint64 amount = FHE.asEuint64(inAmount);
+    function deposit(externalEuint64 inAmount, bytes calldata inputProof) external {
+        euint64 amount = FHE.asEuint64(inAmount, inputProof);
         FHE.allow(amount, address(asset));
         euint64 transferred = asset.confidentialTransferFrom(msg.sender, address(this), amount);
         (, euint64 updated) = FHESafeMath.tryAdd(balances[msg.sender], transferred);

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -53,12 +53,16 @@ const config: HardhatUserConfig = {
     ],
     overrides: {
       // ERC20ConfidentialLib is deployed ONCE PER CHAIN and linked by address into every
-      // consumer. Pinned at 0.8.26 / runs:1 / cancun because that is what the instances
-      // already deployed on chain were compiled with: at these settings this source produces
-      // byte-identical EXECUTABLE code, so a library deployed from this repo behaves exactly
-      // like those, and hosts linked against either are interchangeable. Retuning would
-      // change the runtime code and require a redeploy. Consumers link by address, so their
-      // own bytecode is unaffected by these settings.
+      // consumer, so the artifact must be reproducible: same source + these settings must
+      // always yield the same bytecode, for explorer verification and for consumers checking
+      // what they linked against.
+      //
+      // NOTE: the cofhe 0.7 migration changed this library's ABI (InEuint64 became
+      // externalEuint64 + a trailing proof), so this build is NOT interchangeable with
+      // library instances deployed before 0.7 — it is a new deployment, and every host must
+      // be relinked against it. The 0.8.26 / runs:1 / cancun pin is retained so that this
+      // version is itself reproducible. Consumers link by address, so their own bytecode is
+      // unaffected by these settings.
       "contracts/ERC20Confidential/ERC20ConfidentialLib.sol": {
         version: "0.8.26",
         settings: { evmVersion: "cancun", optimizer: { enabled: true, runs: 1 } },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "beta:snapshot": "changeset version --snapshot beta && changeset publish --tag beta"
   },
   "dependencies": {
-    "@fhenixprotocol/cofhe-contracts": "0.1.3",
+    "@fhenixprotocol/cofhe-contracts": "0.2.0-beta.3",
     "@openzeppelin/contracts": "^5.2.0",
     "@openzeppelin/contracts-upgradeable": "5.4.0",
     "@typechain/ethers-v6": "~0.5.1",
@@ -55,9 +55,9 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.30.0",
-    "@cofhe/hardhat-plugin": "0.5.2",
-    "@cofhe/mock-contracts": "0.5.2",
-    "@cofhe/sdk": "0.5.2",
+    "@cofhe/hardhat-plugin": "0.0.0-alpha-20260818094925",
+    "@cofhe/mock-contracts": "0.0.0-alpha-20260818094925",
+    "@cofhe/sdk": "0.0.0-alpha-20260818094925",
     "@ethersproject/abi": "~5.7.0",
     "@ethersproject/providers": "~5.7.2",
     "@nomicfoundation/hardhat-chai-matchers": "~2.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@fhenixprotocol/cofhe-contracts':
+        specifier: 0.2.0-beta.3
+        version: 0.2.0-beta.3
       '@openzeppelin/contracts':
         specifier: ^5.2.0
         version: 5.4.0
@@ -31,23 +34,20 @@ importers:
         specifier: ^2.30.0
         version: 2.30.0(@types/node@24.1.0)
       '@cofhe/hardhat-plugin':
-        specifier: 0.5.2
-        version: 0.5.2(@fhenixprotocol/cofhe-contracts@0.1.3)(@nomicfoundation/hardhat-ethers@3.0.9(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4)))(@openzeppelin/contracts@5.4.0)(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4))(typescript@5.5.4)(zod@3.25.76)
+        specifier: 0.0.0-alpha-20260818094925
+        version: 0.0.0-alpha-20260818094925(@fhenixprotocol/cofhe-contracts@0.2.0-beta.3)(@nomicfoundation/hardhat-ethers@3.0.9(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4)))(@openzeppelin/contracts@5.4.0)(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4))(typescript@5.5.4)(zod@3.25.76)
       '@cofhe/mock-contracts':
-        specifier: 0.5.2
-        version: 0.5.2
+        specifier: 0.0.0-alpha-20260818094925
+        version: 0.0.0-alpha-20260818094925
       '@cofhe/sdk':
-        specifier: 0.5.2
-        version: 0.5.2(@nomicfoundation/hardhat-ethers@3.0.9(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4)))(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4))(viem@2.38.6(typescript@5.5.4)(zod@3.25.76))
+        specifier: 0.0.0-alpha-20260818094925
+        version: 0.0.0-alpha-20260818094925(@nomicfoundation/hardhat-ethers@3.0.9(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4)))(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4))(viem@2.38.6(typescript@5.5.4)(zod@3.25.76))
       '@ethersproject/abi':
         specifier: ~5.7.0
         version: 5.7.0
       '@ethersproject/providers':
         specifier: ~5.7.2
         version: 5.7.2
-      '@fhenixprotocol/cofhe-contracts':
-        specifier: 0.1.3
-        version: 0.1.3
       '@nomicfoundation/hardhat-chai-matchers':
         specifier: ~2.0.7
         version: 2.0.9(@nomicfoundation/hardhat-ethers@3.0.9(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4)))(chai@4.5.0)(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4))
@@ -212,20 +212,20 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@cofhe/hardhat-plugin@0.5.2':
-    resolution: {integrity: sha512-c4S9VHrSXAEMm1hr6vKxT507x1D1rYa1J52fOn/vIp+4lfcls19uTU8SpeA24up0J6C9cYErW49MTuSWj8kblw==}
+  '@cofhe/hardhat-plugin@0.0.0-alpha-20260818094925':
+    resolution: {integrity: sha512-VRNR+17HK/yfU5nAcNW6F2tLg49oqg6YlFWbw4vV0osfEYLtLSNChVWJa9QqKvo67EldFqtUCgp1P6WLsH3fbw==}
     peerDependencies:
-      '@fhenixprotocol/cofhe-contracts': '>=0.1.3'
+      '@fhenixprotocol/cofhe-contracts': '>=0.2.0-beta.3'
       '@nomicfoundation/hardhat-ethers': ^3.0.0
       '@openzeppelin/contracts': ^5.0.0
       ethers: ^5.0.0 || ^6.0.0
       hardhat: ^2.0.0
 
-  '@cofhe/mock-contracts@0.5.2':
-    resolution: {integrity: sha512-hQw95FzFsslvaK1Nbt3/wHDTWPc7qGSjmFNCDBbWP7eE6QVSwhr+uI07gFUhWhbtwo6vwb2IBcodd4S02K3uFg==}
+  '@cofhe/mock-contracts@0.0.0-alpha-20260818094925':
+    resolution: {integrity: sha512-/gDziyN3LNa5GOuU6P8eaa4x1HRQPgq+zBhI0TcHU1ooA92MAJxggO6yS6e/GqJ6WNo/Le8Jkki0efXmayYqWw==}
 
-  '@cofhe/sdk@0.5.2':
-    resolution: {integrity: sha512-OJ1c6GF5CmpumQhWg4GLxx0V+Gyo3N5XcjuAfXzVy5g9PEGq4VpkfvnDBqmwc0K6+m9kff29Jtw/KfUE5v+xQw==}
+  '@cofhe/sdk@0.0.0-alpha-20260818094925':
+    resolution: {integrity: sha512-lkFnOWH7ixQislffdu0b1gdh66cTbTBWTSb2i8jm1eV53pZbcVEDWK8kWBc0dv1bV8vecCQ2DtjoZ5kwoVG1sw==}
     peerDependencies:
       '@nomicfoundation/hardhat-ethers': ^3.0.0
       '@wagmi/core': ^2.0.0
@@ -389,8 +389,8 @@ packages:
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
 
-  '@fhenixprotocol/cofhe-contracts@0.1.3':
-    resolution: {integrity: sha512-VegEHsy3a6DMHGlzhw5Xbqhp7zYvlK601z5VO5qQeeBjmOXEVhyWvVrpvmJgZfpDoT+bdCL19qExBJzKH5aYvA==}
+  '@fhenixprotocol/cofhe-contracts@0.2.0-beta.3':
+    resolution: {integrity: sha512-tr1AfoWIojKCP92G1VTsfIQIDwR+LHoBH6xX5ZKO4UXW14+sffgZYDJ3PuNaSaP/v1yWgn+5mslEd1/TtlCmfA==}
 
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -3007,8 +3007,8 @@ packages:
   zod@4.0.0:
     resolution: {integrity: sha512-9diLdTPc/L7w/5jI4C3gHYNiGHDV9IZYxo1e5LSD8cabi65WVTWWb+g2BGPEpUUCOxR4D+6O5B0AzyMdUAXwrw==}
 
-  zustand@5.0.1:
-    resolution: {integrity: sha512-pRET7Lao2z+n5R/HduXMio35TncTlSW68WsYBq2Lg1ASspsNGjpwLAsij3RpouyV6+kHMwwwzP0bZPD70/Jx/w==}
+  zustand@5.0.13:
+    resolution: {integrity: sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
       '@types/react': '>=18.0.0'
@@ -3176,11 +3176,11 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@cofhe/hardhat-plugin@0.5.2(@fhenixprotocol/cofhe-contracts@0.1.3)(@nomicfoundation/hardhat-ethers@3.0.9(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4)))(@openzeppelin/contracts@5.4.0)(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4))(typescript@5.5.4)(zod@3.25.76)':
+  '@cofhe/hardhat-plugin@0.0.0-alpha-20260818094925(@fhenixprotocol/cofhe-contracts@0.2.0-beta.3)(@nomicfoundation/hardhat-ethers@3.0.9(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4)))(@openzeppelin/contracts@5.4.0)(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4))(typescript@5.5.4)(zod@3.25.76)':
     dependencies:
-      '@cofhe/mock-contracts': 0.5.2
-      '@cofhe/sdk': 0.5.2(@nomicfoundation/hardhat-ethers@3.0.9(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4)))(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4))(viem@2.38.6(typescript@5.5.4)(zod@3.25.76))
-      '@fhenixprotocol/cofhe-contracts': 0.1.3
+      '@cofhe/mock-contracts': 0.0.0-alpha-20260818094925
+      '@cofhe/sdk': 0.0.0-alpha-20260818094925(@nomicfoundation/hardhat-ethers@3.0.9(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4)))(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4))(viem@2.38.6(typescript@5.5.4)(zod@3.25.76))
+      '@fhenixprotocol/cofhe-contracts': 0.2.0-beta.3
       '@nomicfoundation/hardhat-ethers': 3.0.9(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4))
       '@openzeppelin/contracts': 5.4.0
       chai: 4.5.0
@@ -3199,13 +3199,13 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@cofhe/mock-contracts@0.5.2':
+  '@cofhe/mock-contracts@0.0.0-alpha-20260818094925':
     dependencies:
-      '@fhenixprotocol/cofhe-contracts': 0.1.3
+      '@fhenixprotocol/cofhe-contracts': 0.2.0-beta.3
       '@openzeppelin/contracts': 5.4.0
       '@openzeppelin/contracts-upgradeable': 5.4.0(@openzeppelin/contracts@5.4.0)
 
-  '@cofhe/sdk@0.5.2(@nomicfoundation/hardhat-ethers@3.0.9(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4)))(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4))(viem@2.38.6(typescript@5.5.4)(zod@3.25.76))':
+  '@cofhe/sdk@0.0.0-alpha-20260818094925(@nomicfoundation/hardhat-ethers@3.0.9(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4)))(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4))(viem@2.38.6(typescript@5.5.4)(zod@3.25.76))':
     dependencies:
       iframe-shared-storage: 1.0.34
       immer: 10.1.1
@@ -3214,7 +3214,7 @@ snapshots:
       tweetnacl: 1.0.3
       viem: 2.38.6(typescript@5.5.4)(zod@3.25.76)
       zod: 4.0.0
-      zustand: 5.0.1(immer@10.1.1)
+      zustand: 5.0.13(immer@10.1.1)
     optionalDependencies:
       '@nomicfoundation/hardhat-ethers': 3.0.9(ethers@6.13.7)(hardhat@2.26.1(ts-node@10.9.2(@types/node@24.1.0)(typescript@5.5.4))(typescript@5.5.4))
       ethers: 6.13.7
@@ -3572,7 +3572,7 @@ snapshots:
 
   '@fastify/busboy@2.1.1': {}
 
-  '@fhenixprotocol/cofhe-contracts@0.1.3':
+  '@fhenixprotocol/cofhe-contracts@0.2.0-beta.3':
     dependencies:
       '@openzeppelin/contracts': 5.4.0
 
@@ -6449,6 +6449,6 @@ snapshots:
 
   zod@4.0.0: {}
 
-  zustand@5.0.1(immer@10.1.1):
+  zustand@5.0.13(immer@10.1.1):
     optionalDependencies:
       immer: 10.1.1

--- a/test/ClaimCollision.test.ts
+++ b/test/ClaimCollision.test.ts
@@ -57,7 +57,7 @@ describe("unshield claim-key collision", function () {
 
     await hre.network.provider.send("evm_increaseTime", [11]);
     await hre.network.provider.send("evm_mine");
-    const dec = await aliceClient.decryptForTx(claim.ctHash).withoutPermit().execute();
+    const dec = await aliceClient.decryptForTx(claim.ctHash).withoutACP().execute();
     await (await h.connect(alice).claimUnshielded(claim.id, dec.decryptedValue, dec.signature)).wait();
 
     expect(await h.ledger(alice.address)).to.equal(A); // rate 1 → A public paid to alice
@@ -119,10 +119,10 @@ describe("unshield claim-key collision", function () {
     await hre.network.provider.send("evm_mine");
 
     // Each claims their OWN id and is paid their OWN funds — no cross-theft, no stranding.
-    const decA = await aliceClient.decryptForTx(aliceClaim.ctHash).withoutPermit().execute();
+    const decA = await aliceClient.decryptForTx(aliceClaim.ctHash).withoutACP().execute();
     await (await h.connect(alice).claimUnshielded(aliceClaim.id, decA.decryptedValue, decA.signature)).wait();
 
-    const decB = await bobClient.decryptForTx(bobClaim.ctHash).withoutPermit().execute();
+    const decB = await bobClient.decryptForTx(bobClaim.ctHash).withoutACP().execute();
     await (await h.connect(bob).claimUnshielded(bobClaim.id, decB.decryptedValue, decB.signature)).wait();
 
     expect(await h.ledger(alice.address)).to.equal(A);

--- a/test/ClaimUnshieldedBatch.test.ts
+++ b/test/ClaimUnshieldedBatch.test.ts
@@ -46,7 +46,7 @@ describe("claimUnshieldedBatch", function () {
     const amounts: bigint[] = [];
     const proofs: string[] = [];
     for (const claim of claims) {
-      const dec = await aliceClient.decryptForTx(claim.ctHash).withoutPermit().execute();
+      const dec = await aliceClient.decryptForTx(claim.ctHash).withoutACP().execute();
       ids.push(claim.id);
       amounts.push(dec.decryptedValue);
       proofs.push(dec.signature);

--- a/test/ERC20Confidential.behavior.ts
+++ b/test/ERC20Confidential.behavior.ts
@@ -142,7 +142,7 @@ export function shouldBehaveLikeERC20Confidential(
       await hre.network.provider.send("evm_increaseTime", [11]);
       await hre.network.provider.send("evm_mine");
 
-      const decryption = await bobClient.decryptForTx(ctHash).withoutPermit().execute();
+      const decryption = await bobClient.decryptForTx(ctHash).withoutACP().execute();
 
       await expect(
         token.connect(bob).claimUnshielded(claimId, decryption.decryptedValue, decryption.signature),
@@ -182,7 +182,7 @@ export function shouldBehaveLikeERC20Confidential(
       await hre.network.provider.send("evm_increaseTime", [11]);
       await hre.network.provider.send("evm_mine");
 
-      const decryption = await bobClient.decryptForTx(ctHash).withoutPermit().execute();
+      const decryption = await bobClient.decryptForTx(ctHash).withoutACP().execute();
 
       await expect(
         token.connect(bob).claimUnshielded(claimId, decryption.decryptedValue, decryption.signature),
@@ -228,8 +228,8 @@ export function shouldBehaveLikeERC20Confidential(
       await hre.network.provider.send("evm_increaseTime", [11]);
       await hre.network.provider.send("evm_mine");
 
-      const dec1 = await bobClient.decryptForTx(request1.ctHash).withoutPermit().execute();
-      const dec2 = await bobClient.decryptForTx(request2.ctHash).withoutPermit().execute();
+      const dec1 = await bobClient.decryptForTx(request1.ctHash).withoutACP().execute();
+      const dec2 = await bobClient.decryptForTx(request2.ctHash).withoutACP().execute();
 
       await token.connect(bob).claimUnshielded(request1.claimId, dec1.decryptedValue, dec1.signature);
       await token.connect(bob).claimUnshielded(request2.claimId, dec2.decryptedValue, dec2.signature);
@@ -301,7 +301,7 @@ export function shouldBehaveLikeERC20Confidential(
       await hre.network.provider.send("evm_increaseTime", [11]);
       await hre.network.provider.send("evm_mine");
 
-      const decryption = await bobClient.decryptForTx(ctHash).withoutPermit().execute();
+      const decryption = await bobClient.decryptForTx(ctHash).withoutACP().execute();
       await token.connect(bob).claimUnshielded(claimId, decryption.decryptedValue, decryption.signature);
 
       // Claim drains the pool — unshieldAmount is in confidential units, scale it to public units.
@@ -339,12 +339,15 @@ export function shouldBehaveLikeERC20Confidential(
 
       const transferAmount = BigInt(5 * 1e6);
 
-      const [encTransferInput] = await bobClient.encryptInputs([Encryptable.uint64(transferAmount)]).execute();
+      const [encTransferInput, encTransferInputProof] = await bobClient
+        .encryptInputs([Encryptable.uint64(transferAmount)])
+        .setConsumingContract(await token.getAddress())
+        .execute();
 
       await expect(
         token
           .connect(bob)
-          ["confidentialTransfer(address,(uint256,uint8,uint8,bytes))"](alice.address, encTransferInput),
+          ["confidentialTransfer(address,bytes32,bytes)"](alice.address, encTransferInput, encTransferInputProof),
       ).to.emit(token, "ConfidentialTransfer");
 
       const bobBalance = await token.confidentialBalanceOf(bob.address);
@@ -371,14 +374,17 @@ export function shouldBehaveLikeERC20Confidential(
       expect(await token.isOperator(bob.address, alice.address)).to.equal(true);
 
       const transferAmount = BigInt(3 * 1e6);
-      const [encTransferInput] = await aliceClient.encryptInputs([Encryptable.uint64(transferAmount)]).execute();
+      const [encTransferInput, encTransferInputProof] = await aliceClient
+        .encryptInputs([Encryptable.uint64(transferAmount)])
+        .setConsumingContract(await token.getAddress())
+        .execute();
 
       await expect(
         token
           .connect(alice)
           [
-            "confidentialTransferFrom(address,address,(uint256,uint8,uint8,bytes))"
-          ](bob.address, alice.address, encTransferInput),
+            "confidentialTransferFrom(address,address,bytes32,bytes)"
+          ](bob.address, alice.address, encTransferInput, encTransferInputProof),
       ).to.emit(token, "ConfidentialTransfer");
 
       const bobBalance = await token.confidentialBalanceOf(bob.address);
@@ -395,14 +401,17 @@ export function shouldBehaveLikeERC20Confidential(
       await token.connect(bob).shield(ethers.parseEther("10"));
 
       const transferAmount = BigInt(3 * 1e6);
-      const [encTransferInput] = await aliceClient.encryptInputs([Encryptable.uint64(transferAmount)]).execute();
+      const [encTransferInput, encTransferInputProof] = await aliceClient
+        .encryptInputs([Encryptable.uint64(transferAmount)])
+        .setConsumingContract(await token.getAddress())
+        .execute();
 
       await expect(
         token
           .connect(alice)
           [
-            "confidentialTransferFrom(address,address,(uint256,uint8,uint8,bytes))"
-          ](bob.address, alice.address, encTransferInput),
+            "confidentialTransferFrom(address,address,bytes32,bytes)"
+          ](bob.address, alice.address, encTransferInput, encTransferInputProof),
       ).to.be.revertedWithCustomError(token, "ERC20ConfidentialUnauthorizedSpender");
     });
   });
@@ -425,13 +434,17 @@ export function shouldBehaveLikeERC20Confidential(
         const receiver = await deployReceiver();
 
         const transferValue = BigInt(1 * 1e6);
-        const [encTransferInput] = await bobClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+        const [encTransferInput, encTransferInputProof] = await bobClient
+          .encryptInputs([Encryptable.uint64(transferValue)])
+          .setConsumingContract(await token.getAddress())
+          .execute();
 
-        return { token, bob, alice, receiver, encTransferInput, transferValue };
+        return { token, bob, alice, receiver, encTransferInput, encTransferInputProof, transferValue };
       }
 
       it("should transfer with callback to receiver (success)", async function () {
-        const { token, bob, receiver, encTransferInput, transferValue } = await setupTransferAndCallFixture();
+        const { token, bob, receiver, encTransferInput, encTransferInputProof, transferValue } =
+          await setupTransferAndCallFixture();
         const receiverAddress = await receiver.getAddress();
 
         await prepExpectFHERC20BalancesChange(token, bob.address);
@@ -442,8 +455,8 @@ export function shouldBehaveLikeERC20Confidential(
         const tx = await token
           .connect(bob)
           [
-            "confidentialTransferAndCall(address,(uint256,uint8,uint8,bytes),bytes)"
-          ](receiverAddress, encTransferInput, callData);
+            "confidentialTransferAndCall(address,bytes32,bytes,bytes)"
+          ](receiverAddress, encTransferInput, callData, encTransferInputProof);
 
         await expect(tx).to.emit(receiver, "ConfidentialTransferCallback").withArgs(true);
 
@@ -452,7 +465,7 @@ export function shouldBehaveLikeERC20Confidential(
       });
 
       it("should transfer with callback to receiver (failure - refund)", async function () {
-        const { token, bob, receiver, encTransferInput } = await setupTransferAndCallFixture();
+        const { token, bob, receiver, encTransferInput, encTransferInputProof } = await setupTransferAndCallFixture();
         const receiverAddress = await receiver.getAddress();
 
         await prepExpectFHERC20BalancesChange(token, bob.address);
@@ -464,8 +477,8 @@ export function shouldBehaveLikeERC20Confidential(
           token
             .connect(bob)
             [
-              "confidentialTransferAndCall(address,(uint256,uint8,uint8,bytes),bytes)"
-            ](receiverAddress, encTransferInput, callData),
+              "confidentialTransferAndCall(address,bytes32,bytes,bytes)"
+            ](receiverAddress, encTransferInput, callData, encTransferInputProof),
         ).to.emit(receiver, "ConfidentialTransferCallback");
 
         await expectFHERC20BalancesChange(token, bob.address, 0n);
@@ -473,7 +486,8 @@ export function shouldBehaveLikeERC20Confidential(
       });
 
       it("should transfer with callback to EOA (always succeeds)", async function () {
-        const { token, bob, alice, encTransferInput, transferValue } = await setupTransferAndCallFixture();
+        const { token, bob, alice, encTransferInput, encTransferInputProof, transferValue } =
+          await setupTransferAndCallFixture();
 
         await prepExpectFHERC20BalancesChange(token, bob.address);
         await prepExpectFHERC20BalancesChange(token, alice.address);
@@ -481,8 +495,8 @@ export function shouldBehaveLikeERC20Confidential(
         const tx = await token
           .connect(bob)
           [
-            "confidentialTransferAndCall(address,(uint256,uint8,uint8,bytes),bytes)"
-          ](alice.address, encTransferInput, "0x");
+            "confidentialTransferAndCall(address,bytes32,bytes,bytes)"
+          ](alice.address, encTransferInput, "0x", encTransferInputProof);
 
         await expect(tx).to.emit(token, "ConfidentialTransfer");
 
@@ -491,7 +505,7 @@ export function shouldBehaveLikeERC20Confidential(
       });
 
       it("should revert with custom error from callback", async function () {
-        const { token, bob, receiver, encTransferInput } = await setupTransferAndCallFixture();
+        const { token, bob, receiver, encTransferInput, encTransferInputProof } = await setupTransferAndCallFixture();
 
         const callData = ethers.AbiCoder.defaultAbiCoder().encode(["uint8"], [2]);
 
@@ -499,22 +513,22 @@ export function shouldBehaveLikeERC20Confidential(
           token
             .connect(bob)
             [
-              "confidentialTransferAndCall(address,(uint256,uint8,uint8,bytes),bytes)"
-            ](await receiver.getAddress(), encTransferInput, callData),
+              "confidentialTransferAndCall(address,bytes32,bytes,bytes)"
+            ](await receiver.getAddress(), encTransferInput, callData, encTransferInputProof),
         )
           .to.be.revertedWithCustomError(receiver, "InvalidInput")
           .withArgs(2);
       });
 
       it("should revert on transfer to zero address", async function () {
-        const { token, bob, encTransferInput } = await setupTransferAndCallFixture();
+        const { token, bob, encTransferInput, encTransferInputProof } = await setupTransferAndCallFixture();
 
         await expect(
           token
             .connect(bob)
             [
-              "confidentialTransferAndCall(address,(uint256,uint8,uint8,bytes),bytes)"
-            ](ZeroAddress, encTransferInput, "0x"),
+              "confidentialTransferAndCall(address,bytes32,bytes,bytes)"
+            ](ZeroAddress, encTransferInput, "0x", encTransferInputProof),
         ).to.be.revertedWithCustomError(token, "ConfidentialInvalidReceiver"); // was ERC20InvalidReceiver pre-Core
       });
     });
@@ -541,7 +555,10 @@ export function shouldBehaveLikeERC20Confidential(
         await token.connect(bob).setOperator(alice.address, timestamp);
 
         const transferValue = BigInt(1 * 1e6);
-        const [encTransferInput] = await aliceClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+        const [encTransferInput, encTransferInputProof] = await aliceClient
+          .encryptInputs([Encryptable.uint64(transferValue)])
+          .setConsumingContract(await token.getAddress())
+          .execute();
 
         await prepExpectFHERC20BalancesChange(token, bob.address);
         await prepExpectFHERC20BalancesChange(token, receiverAddress);
@@ -551,8 +568,8 @@ export function shouldBehaveLikeERC20Confidential(
         const tx = await token
           .connect(alice)
           [
-            "confidentialTransferFromAndCall(address,address,(uint256,uint8,uint8,bytes),bytes)"
-          ](bob.address, receiverAddress, encTransferInput, callData);
+            "confidentialTransferFromAndCall(address,address,bytes32,bytes,bytes)"
+          ](bob.address, receiverAddress, encTransferInput, callData, encTransferInputProof);
 
         await expect(tx).to.emit(receiver, "ConfidentialTransferCallback").withArgs(true);
 
@@ -568,7 +585,10 @@ export function shouldBehaveLikeERC20Confidential(
         await token.connect(bob).setOperator(alice.address, timestamp);
 
         const transferValue = BigInt(1 * 1e6);
-        const [encTransferInput] = await aliceClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+        const [encTransferInput, encTransferInputProof] = await aliceClient
+          .encryptInputs([Encryptable.uint64(transferValue)])
+          .setConsumingContract(await token.getAddress())
+          .execute();
 
         await prepExpectFHERC20BalancesChange(token, bob.address);
         await prepExpectFHERC20BalancesChange(token, receiverAddress);
@@ -579,8 +599,8 @@ export function shouldBehaveLikeERC20Confidential(
           token
             .connect(alice)
             [
-              "confidentialTransferFromAndCall(address,address,(uint256,uint8,uint8,bytes),bytes)"
-            ](bob.address, receiverAddress, encTransferInput, callData),
+              "confidentialTransferFromAndCall(address,address,bytes32,bytes,bytes)"
+            ](bob.address, receiverAddress, encTransferInput, callData, encTransferInputProof),
         ).to.emit(receiver, "ConfidentialTransferCallback");
 
         await expectFHERC20BalancesChange(token, bob.address, 0n);
@@ -594,7 +614,10 @@ export function shouldBehaveLikeERC20Confidential(
         await token.connect(bob).setOperator(eve.address, timestamp);
 
         const transferValue = BigInt(1 * 1e6);
-        const [encTransferInput] = await eveClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+        const [encTransferInput, encTransferInputProof] = await eveClient
+          .encryptInputs([Encryptable.uint64(transferValue)])
+          .setConsumingContract(await token.getAddress())
+          .execute();
 
         await prepExpectFHERC20BalancesChange(token, bob.address);
         await prepExpectFHERC20BalancesChange(token, alice.address);
@@ -602,8 +625,8 @@ export function shouldBehaveLikeERC20Confidential(
         const tx = await token
           .connect(eve)
           [
-            "confidentialTransferFromAndCall(address,address,(uint256,uint8,uint8,bytes),bytes)"
-          ](bob.address, alice.address, encTransferInput, "0x");
+            "confidentialTransferFromAndCall(address,address,bytes32,bytes,bytes)"
+          ](bob.address, alice.address, encTransferInput, "0x", encTransferInputProof);
 
         await expect(tx).to.emit(token, "ConfidentialTransfer");
 
@@ -615,7 +638,10 @@ export function shouldBehaveLikeERC20Confidential(
         const { token, bob, alice, receiver, aliceClient } = await setupTransferFromAndCallFixture();
 
         const transferValue = BigInt(1 * 1e6);
-        const [encTransferInput] = await aliceClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+        const [encTransferInput, encTransferInputProof] = await aliceClient
+          .encryptInputs([Encryptable.uint64(transferValue)])
+          .setConsumingContract(await token.getAddress())
+          .execute();
 
         const callData = ethers.AbiCoder.defaultAbiCoder().encode(["uint8"], [1]);
 
@@ -623,8 +649,8 @@ export function shouldBehaveLikeERC20Confidential(
           token
             .connect(alice)
             [
-              "confidentialTransferFromAndCall(address,address,(uint256,uint8,uint8,bytes),bytes)"
-            ](bob.address, await receiver.getAddress(), encTransferInput, callData),
+              "confidentialTransferFromAndCall(address,address,bytes32,bytes,bytes)"
+            ](bob.address, await receiver.getAddress(), encTransferInput, callData, encTransferInputProof),
         ).to.be.revertedWithCustomError(token, "ERC20ConfidentialUnauthorizedSpender");
       });
 
@@ -635,7 +661,10 @@ export function shouldBehaveLikeERC20Confidential(
         await token.connect(bob).setOperator(alice.address, timestamp);
 
         const transferValue = BigInt(1 * 1e6);
-        const [encTransferInput] = await aliceClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+        const [encTransferInput, encTransferInputProof] = await aliceClient
+          .encryptInputs([Encryptable.uint64(transferValue)])
+          .setConsumingContract(await token.getAddress())
+          .execute();
 
         const callData = ethers.AbiCoder.defaultAbiCoder().encode(["uint8"], [2]);
 
@@ -643,8 +672,8 @@ export function shouldBehaveLikeERC20Confidential(
           token
             .connect(alice)
             [
-              "confidentialTransferFromAndCall(address,address,(uint256,uint8,uint8,bytes),bytes)"
-            ](bob.address, await receiver.getAddress(), encTransferInput, callData),
+              "confidentialTransferFromAndCall(address,address,bytes32,bytes,bytes)"
+            ](bob.address, await receiver.getAddress(), encTransferInput, callData, encTransferInputProof),
         )
           .to.be.revertedWithCustomError(receiver, "InvalidInput")
           .withArgs(2);
@@ -657,14 +686,17 @@ export function shouldBehaveLikeERC20Confidential(
         await token.connect(bob).setOperator(alice.address, timestamp);
 
         const transferValue = BigInt(1 * 1e6);
-        const [encTransferInput] = await aliceClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+        const [encTransferInput, encTransferInputProof] = await aliceClient
+          .encryptInputs([Encryptable.uint64(transferValue)])
+          .setConsumingContract(await token.getAddress())
+          .execute();
 
         await expect(
           token
             .connect(alice)
             [
-              "confidentialTransferFromAndCall(address,address,(uint256,uint8,uint8,bytes),bytes)"
-            ](bob.address, ZeroAddress, encTransferInput, "0x"),
+              "confidentialTransferFromAndCall(address,address,bytes32,bytes,bytes)"
+            ](bob.address, ZeroAddress, encTransferInput, "0x", encTransferInputProof),
         ).to.be.revertedWithCustomError(token, "ConfidentialInvalidReceiver"); // was ERC20InvalidReceiver pre-Core
       });
     });
@@ -702,7 +734,7 @@ export function shouldBehaveLikeERC20Confidential(
         await hre.network.provider.send("evm_increaseTime", [11]);
         await hre.network.provider.send("evm_mine");
 
-        const decryption = await bobClient.decryptForTx(ctHash).withoutPermit().execute();
+        const decryption = await bobClient.decryptForTx(ctHash).withoutACP().execute();
         await token.connect(bob).claimUnshielded(claimId, decryption.decryptedValue, decryption.signature);
 
         expect(await token.balanceOf(bob.address)).to.equal(amount);
@@ -740,7 +772,7 @@ export function shouldBehaveLikeERC20Confidential(
         await hre.network.provider.send("evm_increaseTime", [11]);
         await hre.network.provider.send("evm_mine");
 
-        const decryption = await bobClient.decryptForTx(ctHash).withoutPermit().execute();
+        const decryption = await bobClient.decryptForTx(ctHash).withoutACP().execute();
         await token.connect(bob).claimUnshielded(claimId, decryption.decryptedValue, decryption.signature);
 
         expect(await token.balanceOf(bob.address)).to.equal(amount);
@@ -779,7 +811,7 @@ export function shouldBehaveLikeERC20Confidential(
         await hre.network.provider.send("evm_increaseTime", [11]);
         await hre.network.provider.send("evm_mine");
 
-        const decryption = await bobClient.decryptForTx(ctHash).withoutPermit().execute();
+        const decryption = await bobClient.decryptForTx(ctHash).withoutACP().execute();
         await token.connect(bob).claimUnshielded(claimId, decryption.decryptedValue, decryption.signature);
 
         expect(await token.balanceOf(bob.address)).to.equal(publicAmount);

--- a/test/FHERC20.behavior.ts
+++ b/test/FHERC20.behavior.ts
@@ -58,13 +58,13 @@ export function getIERC7984InterfaceId(): string {
     "confidentialBalanceOf(address)",
     "isOperator(address,address)",
     "setOperator(address,uint48)",
-    "confidentialTransfer(address,(uint256,uint8,uint8,bytes))",
+    "confidentialTransfer(address,bytes32,bytes)",
     "confidentialTransfer(address,bytes32)",
-    "confidentialTransferFrom(address,address,(uint256,uint8,uint8,bytes))",
+    "confidentialTransferFrom(address,address,bytes32,bytes)",
     "confidentialTransferFrom(address,address,bytes32)",
-    "confidentialTransferAndCall(address,(uint256,uint8,uint8,bytes),bytes)",
+    "confidentialTransferAndCall(address,bytes32,bytes,bytes)",
     "confidentialTransferAndCall(address,bytes32,bytes)",
-    "confidentialTransferFromAndCall(address,address,(uint256,uint8,uint8,bytes),bytes)",
+    "confidentialTransferFromAndCall(address,address,bytes32,bytes,bytes)",
     "confidentialTransferFromAndCall(address,address,bytes32,bytes)",
   ]);
 }
@@ -165,7 +165,10 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
       await token.mint(alice.address, mintValue);
 
       const transferValue = 1_000_000n;
-      const [encTransferInput] = await bobClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+      const [encTransferInput, encTransferInputProof] = await bobClient
+        .encryptInputs([Encryptable.uint64(transferValue)])
+        .setConsumingContract(await token.getAddress())
+        .execute();
 
       await prepExpectFHERC20BalancesChange(token, bob.address);
       await prepExpectFHERC20BalancesChange(token, alice.address);
@@ -173,7 +176,7 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
       await expect(
         token
           .connect(bob)
-          ["confidentialTransfer(address,(uint256,uint8,uint8,bytes))"](alice.address, encTransferInput),
+          ["confidentialTransfer(address,bytes32,bytes)"](alice.address, encTransferInput, encTransferInputProof),
       ).to.emit(token, "ConfidentialTransfer");
 
       await expectFHERC20BalancesChange(token, bob.address, -1n * transferValue);
@@ -186,10 +189,15 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
       await token.mint(bob.address, 10_000_000n);
 
       const transferValue = 1_000_000n;
-      const [encTransferInput] = await bobClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+      const [encTransferInput, encTransferInputProof] = await bobClient
+        .encryptInputs([Encryptable.uint64(transferValue)])
+        .setConsumingContract(await token.getAddress())
+        .execute();
 
       await expect(
-        token.connect(bob)["confidentialTransfer(address,(uint256,uint8,uint8,bytes))"](ZeroAddress, encTransferInput),
+        token
+          .connect(bob)
+          ["confidentialTransfer(address,bytes32,bytes)"](ZeroAddress, encTransferInput, encTransferInputProof),
       ).to.be.revertedWithCustomError(token, "FHERC20InvalidReceiver");
     });
 
@@ -201,14 +209,17 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
       await token.mint(alice.address, mintValue);
 
       const transferValue = 10_000_000n;
-      const [encTransferInput] = await bobClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+      const [encTransferInput, encTransferInputProof] = await bobClient
+        .encryptInputs([Encryptable.uint64(transferValue)])
+        .setConsumingContract(await token.getAddress())
+        .execute();
 
       await prepExpectFHERC20BalancesChange(token, bob.address);
       await prepExpectFHERC20BalancesChange(token, alice.address);
 
       await token
         .connect(bob)
-        ["confidentialTransfer(address,(uint256,uint8,uint8,bytes))"](alice.address, encTransferInput);
+        ["confidentialTransfer(address,bytes32,bytes)"](alice.address, encTransferInput, encTransferInputProof);
 
       await expectFHERC20BalancesChange(token, bob.address, 0n);
       await expectFHERC20BalancesChange(token, alice.address, 0n);
@@ -283,7 +294,10 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
       await token.connect(bob).setOperator(alice.address, timestamp);
 
       const transferValue = 1_000_000n;
-      const [encTransferInput] = await aliceClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+      const [encTransferInput, encTransferInputProof] = await aliceClient
+        .encryptInputs([Encryptable.uint64(transferValue)])
+        .setConsumingContract(await token.getAddress())
+        .execute();
 
       await prepExpectFHERC20BalancesChange(token, bob.address);
       await prepExpectFHERC20BalancesChange(token, alice.address);
@@ -292,8 +306,8 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
         token
           .connect(alice)
           [
-            "confidentialTransferFrom(address,address,(uint256,uint8,uint8,bytes))"
-          ](bob.address, alice.address, encTransferInput),
+            "confidentialTransferFrom(address,address,bytes32,bytes)"
+          ](bob.address, alice.address, encTransferInput, encTransferInputProof),
       ).to.emit(token, "ConfidentialTransfer");
 
       await expectFHERC20BalancesChange(token, bob.address, -1n * transferValue);
@@ -307,7 +321,10 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
       await token.connect(bob).setOperator(eve.address, timestamp);
 
       const transferValue = 1_000_000n;
-      const [encTransferInput] = await eveClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+      const [encTransferInput, encTransferInputProof] = await eveClient
+        .encryptInputs([Encryptable.uint64(transferValue)])
+        .setConsumingContract(await token.getAddress())
+        .execute();
 
       await prepExpectFHERC20BalancesChange(token, bob.address);
       await prepExpectFHERC20BalancesChange(token, alice.address);
@@ -316,8 +333,8 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
         token
           .connect(eve)
           [
-            "confidentialTransferFrom(address,address,(uint256,uint8,uint8,bytes))"
-          ](bob.address, alice.address, encTransferInput),
+            "confidentialTransferFrom(address,address,bytes32,bytes)"
+          ](bob.address, alice.address, encTransferInput, encTransferInputProof),
       ).to.emit(token, "ConfidentialTransfer");
 
       await expectFHERC20BalancesChange(token, bob.address, -1n * transferValue);
@@ -338,12 +355,18 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
       await token.connect(bob).setOperator(vaultAddress, timestamp);
 
       const transferValue = 1_000_000n;
-      const [encTransferInput] = await bobClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+      const [encTransferInput, encTransferInputProof] = await bobClient
+        .encryptInputs([Encryptable.uint64(transferValue)])
+        .setConsumingContract(await vault.getAddress())
+        .execute();
 
       await prepExpectFHERC20BalancesChange(token, bob.address);
       await prepExpectFHERC20BalancesChange(token, vaultAddress);
 
-      await expect(vault.connect(bob).deposit(encTransferInput)).to.emit(token, "ConfidentialTransfer");
+      await expect(vault.connect(bob).deposit(encTransferInput, encTransferInputProof)).to.emit(
+        token,
+        "ConfidentialTransfer",
+      );
 
       await expectFHERC20BalancesChange(token, bob.address, -1n * transferValue);
       await expectFHERC20BalancesChange(token, vaultAddress, transferValue);
@@ -356,14 +379,17 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
       await token.connect(bob).setOperator(alice.address, timestamp);
 
       const transferValue = 1_000_000n;
-      const [encTransferInput] = await aliceClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+      const [encTransferInput, encTransferInputProof] = await aliceClient
+        .encryptInputs([Encryptable.uint64(transferValue)])
+        .setConsumingContract(await token.getAddress())
+        .execute();
 
       await expect(
         token
           .connect(alice)
           [
-            "confidentialTransferFrom(address,address,(uint256,uint8,uint8,bytes))"
-          ](bob.address, ZeroAddress, encTransferInput),
+            "confidentialTransferFrom(address,address,bytes32,bytes)"
+          ](bob.address, ZeroAddress, encTransferInput, encTransferInputProof),
       ).to.be.revertedWithCustomError(token, "FHERC20InvalidReceiver");
     });
 
@@ -374,14 +400,17 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
       await token.connect(bob).setOperator(eve.address, timestamp);
 
       const transferValue = 1_000_000n;
-      const [encTransferInput] = await aliceClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+      const [encTransferInput, encTransferInputProof] = await aliceClient
+        .encryptInputs([Encryptable.uint64(transferValue)])
+        .setConsumingContract(await token.getAddress())
+        .execute();
 
       await expect(
         token
           .connect(alice)
           [
-            "confidentialTransferFrom(address,address,(uint256,uint8,uint8,bytes))"
-          ](bob.address, alice.address, encTransferInput),
+            "confidentialTransferFrom(address,address,bytes32,bytes)"
+          ](bob.address, alice.address, encTransferInput, encTransferInputProof),
       ).to.be.revertedWithCustomError(token, "FHERC20UnauthorizedSpender");
     });
   });
@@ -398,13 +427,17 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
       await receiver.waitForDeployment();
 
       const transferValue = 1_000_000n;
-      const [encTransferInput] = await bobClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+      const [encTransferInput, encTransferInputProof] = await bobClient
+        .encryptInputs([Encryptable.uint64(transferValue)])
+        .setConsumingContract(await token.getAddress())
+        .execute();
 
-      return { token, bob, alice, eve, receiver, encTransferInput, transferValue };
+      return { token, bob, alice, eve, receiver, encTransferInput, encTransferInputProof, transferValue };
     };
 
     it("should transfer with callback to receiver (success)", async function () {
-      const { token, bob, receiver, encTransferInput, transferValue } = await setupTransferAndCallFixture();
+      const { token, bob, receiver, encTransferInput, encTransferInputProof, transferValue } =
+        await setupTransferAndCallFixture();
 
       const receiverAddress = await receiver.getAddress();
 
@@ -416,8 +449,8 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
       const tx = await token
         .connect(bob)
         [
-          "confidentialTransferAndCall(address,(uint256,uint8,uint8,bytes),bytes)"
-        ](receiverAddress, encTransferInput, callData);
+          "confidentialTransferAndCall(address,bytes32,bytes,bytes)"
+        ](receiverAddress, encTransferInput, callData, encTransferInputProof);
 
       await expect(tx).to.emit(receiver, "ConfidentialTransferCallback").withArgs(true);
 
@@ -426,7 +459,7 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
     });
 
     it("should transfer with callback to receiver (failure - refund)", async function () {
-      const { token, bob, receiver, encTransferInput } = await setupTransferAndCallFixture();
+      const { token, bob, receiver, encTransferInput, encTransferInputProof } = await setupTransferAndCallFixture();
 
       const receiverAddress = await receiver.getAddress();
 
@@ -439,8 +472,8 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
         token
           .connect(bob)
           [
-            "confidentialTransferAndCall(address,(uint256,uint8,uint8,bytes),bytes)"
-          ](receiverAddress, encTransferInput, callData),
+            "confidentialTransferAndCall(address,bytes32,bytes,bytes)"
+          ](receiverAddress, encTransferInput, callData, encTransferInputProof),
       ).to.emit(receiver, "ConfidentialTransferCallback");
 
       await expectFHERC20BalancesChange(token, bob.address, 0n);
@@ -448,7 +481,8 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
     });
 
     it("should transfer with callback to EOA (always succeeds)", async function () {
-      const { token, bob, alice, encTransferInput, transferValue } = await setupTransferAndCallFixture();
+      const { token, bob, alice, encTransferInput, encTransferInputProof, transferValue } =
+        await setupTransferAndCallFixture();
 
       await token.mint(alice.address, 1_000_000n);
 
@@ -458,8 +492,8 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
       const tx = await token
         .connect(bob)
         [
-          "confidentialTransferAndCall(address,(uint256,uint8,uint8,bytes),bytes)"
-        ](alice.address, encTransferInput, "0x");
+          "confidentialTransferAndCall(address,bytes32,bytes,bytes)"
+        ](alice.address, encTransferInput, "0x", encTransferInputProof);
 
       await expect(tx).to.emit(token, "ConfidentialTransfer");
 
@@ -468,7 +502,7 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
     });
 
     it("should revert with custom error from callback", async function () {
-      const { token, bob, receiver, encTransferInput } = await setupTransferAndCallFixture();
+      const { token, bob, receiver, encTransferInput, encTransferInputProof } = await setupTransferAndCallFixture();
 
       const callData = ethers.AbiCoder.defaultAbiCoder().encode(["uint8"], [2]);
 
@@ -476,22 +510,22 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
         token
           .connect(bob)
           [
-            "confidentialTransferAndCall(address,(uint256,uint8,uint8,bytes),bytes)"
-          ](await receiver.getAddress(), encTransferInput, callData),
+            "confidentialTransferAndCall(address,bytes32,bytes,bytes)"
+          ](await receiver.getAddress(), encTransferInput, callData, encTransferInputProof),
       )
         .to.be.revertedWithCustomError(receiver, "InvalidInput")
         .withArgs(2);
     });
 
     it("should revert on transfer to zero address", async function () {
-      const { token, bob, encTransferInput } = await setupTransferAndCallFixture();
+      const { token, bob, encTransferInput, encTransferInputProof } = await setupTransferAndCallFixture();
 
       await expect(
         token
           .connect(bob)
           [
-            "confidentialTransferAndCall(address,(uint256,uint8,uint8,bytes),bytes)"
-          ](ZeroAddress, encTransferInput, "0x"),
+            "confidentialTransferAndCall(address,bytes32,bytes,bytes)"
+          ](ZeroAddress, encTransferInput, "0x", encTransferInputProof),
       ).to.be.revertedWithCustomError(token, "FHERC20InvalidReceiver");
     });
   });
@@ -520,7 +554,10 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
       await token.connect(bob).setOperator(alice.address, timestamp);
 
       const transferValue = 1_000_000n;
-      const [encTransferInput] = await aliceClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+      const [encTransferInput, encTransferInputProof] = await aliceClient
+        .encryptInputs([Encryptable.uint64(transferValue)])
+        .setConsumingContract(await token.getAddress())
+        .execute();
 
       await prepExpectFHERC20BalancesChange(token, bob.address);
       await prepExpectFHERC20BalancesChange(token, receiverAddress);
@@ -530,8 +567,8 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
       const tx = await token
         .connect(alice)
         [
-          "confidentialTransferFromAndCall(address,address,(uint256,uint8,uint8,bytes),bytes)"
-        ](bob.address, receiverAddress, encTransferInput, callData);
+          "confidentialTransferFromAndCall(address,address,bytes32,bytes,bytes)"
+        ](bob.address, receiverAddress, encTransferInput, callData, encTransferInputProof);
 
       await expect(tx).to.emit(receiver, "ConfidentialTransferCallback").withArgs(true);
 
@@ -548,7 +585,10 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
       await token.connect(bob).setOperator(alice.address, timestamp);
 
       const transferValue = 1_000_000n;
-      const [encTransferInput] = await aliceClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+      const [encTransferInput, encTransferInputProof] = await aliceClient
+        .encryptInputs([Encryptable.uint64(transferValue)])
+        .setConsumingContract(await token.getAddress())
+        .execute();
 
       await prepExpectFHERC20BalancesChange(token, bob.address);
       await prepExpectFHERC20BalancesChange(token, receiverAddress);
@@ -559,8 +599,8 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
         token
           .connect(alice)
           [
-            "confidentialTransferFromAndCall(address,address,(uint256,uint8,uint8,bytes),bytes)"
-          ](bob.address, receiverAddress, encTransferInput, callData),
+            "confidentialTransferFromAndCall(address,address,bytes32,bytes,bytes)"
+          ](bob.address, receiverAddress, encTransferInput, callData, encTransferInputProof),
       ).to.emit(receiver, "ConfidentialTransferCallback");
 
       await expectFHERC20BalancesChange(token, bob.address, 0n);
@@ -574,7 +614,10 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
       await token.connect(bob).setOperator(eve.address, timestamp);
 
       const transferValue = 1_000_000n;
-      const [encTransferInput] = await eveClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+      const [encTransferInput, encTransferInputProof] = await eveClient
+        .encryptInputs([Encryptable.uint64(transferValue)])
+        .setConsumingContract(await token.getAddress())
+        .execute();
 
       await prepExpectFHERC20BalancesChange(token, bob.address);
       await prepExpectFHERC20BalancesChange(token, alice.address);
@@ -582,8 +625,8 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
       const tx = await token
         .connect(eve)
         [
-          "confidentialTransferFromAndCall(address,address,(uint256,uint8,uint8,bytes),bytes)"
-        ](bob.address, alice.address, encTransferInput, "0x");
+          "confidentialTransferFromAndCall(address,address,bytes32,bytes,bytes)"
+        ](bob.address, alice.address, encTransferInput, "0x", encTransferInputProof);
 
       await expect(tx).to.emit(token, "ConfidentialTransfer");
 
@@ -595,7 +638,10 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
       const { token, bob, alice, receiver, aliceClient } = await setupTransferFromAndCallFixture();
 
       const transferValue = 1_000_000n;
-      const [encTransferInput] = await aliceClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+      const [encTransferInput, encTransferInputProof] = await aliceClient
+        .encryptInputs([Encryptable.uint64(transferValue)])
+        .setConsumingContract(await token.getAddress())
+        .execute();
 
       const callData = ethers.AbiCoder.defaultAbiCoder().encode(["uint8"], [1]);
 
@@ -603,8 +649,8 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
         token
           .connect(alice)
           [
-            "confidentialTransferFromAndCall(address,address,(uint256,uint8,uint8,bytes),bytes)"
-          ](bob.address, await receiver.getAddress(), encTransferInput, callData),
+            "confidentialTransferFromAndCall(address,address,bytes32,bytes,bytes)"
+          ](bob.address, await receiver.getAddress(), encTransferInput, callData, encTransferInputProof),
       ).to.be.revertedWithCustomError(token, "FHERC20UnauthorizedSpender");
     });
 
@@ -615,7 +661,10 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
       await token.connect(bob).setOperator(alice.address, timestamp);
 
       const transferValue = 1_000_000n;
-      const [encTransferInput] = await aliceClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+      const [encTransferInput, encTransferInputProof] = await aliceClient
+        .encryptInputs([Encryptable.uint64(transferValue)])
+        .setConsumingContract(await token.getAddress())
+        .execute();
 
       const callData = ethers.AbiCoder.defaultAbiCoder().encode(["uint8"], [2]);
 
@@ -623,8 +672,8 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
         token
           .connect(alice)
           [
-            "confidentialTransferFromAndCall(address,address,(uint256,uint8,uint8,bytes),bytes)"
-          ](bob.address, await receiver.getAddress(), encTransferInput, callData),
+            "confidentialTransferFromAndCall(address,address,bytes32,bytes,bytes)"
+          ](bob.address, await receiver.getAddress(), encTransferInput, callData, encTransferInputProof),
       )
         .to.be.revertedWithCustomError(receiver, "InvalidInput")
         .withArgs(2);
@@ -637,14 +686,17 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
       await token.connect(bob).setOperator(alice.address, timestamp);
 
       const transferValue = 1_000_000n;
-      const [encTransferInput] = await aliceClient.encryptInputs([Encryptable.uint64(transferValue)]).execute();
+      const [encTransferInput, encTransferInputProof] = await aliceClient
+        .encryptInputs([Encryptable.uint64(transferValue)])
+        .setConsumingContract(await token.getAddress())
+        .execute();
 
       await expect(
         token
           .connect(alice)
           [
-            "confidentialTransferFromAndCall(address,address,(uint256,uint8,uint8,bytes),bytes)"
-          ](bob.address, ZeroAddress, encTransferInput, "0x"),
+            "confidentialTransferFromAndCall(address,address,bytes32,bytes,bytes)"
+          ](bob.address, ZeroAddress, encTransferInput, "0x", encTransferInputProof),
       ).to.be.revertedWithCustomError(token, "FHERC20InvalidReceiver");
     });
   });
@@ -686,8 +738,11 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
       await token.mint(bob.address, 5_000_000n);
       expect(await token.balanceOf(bob.address)).to.equal(base + tick);
 
-      const [enc] = await bobClient.encryptInputs([Encryptable.uint64(1_000_000n)]).execute();
-      await token.connect(bob)["confidentialTransfer(address,(uint256,uint8,uint8,bytes))"](alice.address, enc);
+      const [enc, encProof] = await bobClient
+        .encryptInputs([Encryptable.uint64(1_000_000n)])
+        .setConsumingContract(await token.getAddress())
+        .execute();
+      await token.connect(bob)["confidentialTransfer(address,bytes32,bytes)"](alice.address, enc, encProof);
 
       expect(await token.balanceOf(bob.address)).to.equal(base);
       expect(await token.balanceOf(alice.address)).to.equal(base + tick);
@@ -700,8 +755,11 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
       expect(await token.balanceOf(bob.address)).to.equal(base + tick);
 
       for (let i = 0; i < 4; i++) {
-        const [enc] = await bobClient.encryptInputs([Encryptable.uint64(100_000n)]).execute();
-        await token.connect(bob)["confidentialTransfer(address,(uint256,uint8,uint8,bytes))"](alice.address, enc);
+        const [enc, encProof] = await bobClient
+          .encryptInputs([Encryptable.uint64(100_000n)])
+          .setConsumingContract(await token.getAddress())
+          .execute();
+        await token.connect(bob)["confidentialTransfer(address,bytes32,bytes)"](alice.address, enc, encProof);
       }
 
       expect(await token.balanceOf(bob.address)).to.equal(79_839_997n * tick);
@@ -798,8 +856,11 @@ export function shouldBehaveLikeFHERC20(setupFixture: SetupFixtureFn, deployWith
       await token.mint(bob.address, 1_000_000n);
       expect(await token.balanceOf(bob.address)).to.equal(base + tick);
 
-      const [enc] = await bobClient.encryptInputs([Encryptable.uint64(100_000n)]).execute();
-      await token.connect(bob)["confidentialTransfer(address,(uint256,uint8,uint8,bytes))"](alice.address, enc);
+      const [enc, encProof] = await bobClient
+        .encryptInputs([Encryptable.uint64(100_000n)])
+        .setConsumingContract(await token.getAddress())
+        .execute();
+      await token.connect(bob)["confidentialTransfer(address,bytes32,bytes)"](alice.address, enc, encProof);
 
       expect(await token.balanceOf(bob.address)).to.equal(base);
       expect(await token.balanceOf(alice.address)).to.equal(base + tick);

--- a/test/FHERC20ERC20Wrapper.test.ts
+++ b/test/FHERC20ERC20Wrapper.test.ts
@@ -225,7 +225,7 @@ describe("FHERC20ERC20Wrapper", function () {
       await hre.network.provider.send("evm_increaseTime", [11]);
       await hre.network.provider.send("evm_mine");
 
-      const decryption = await bobClient.decryptForTx(ctHash).withoutPermit().execute();
+      const decryption = await bobClient.decryptForTx(ctHash).withoutACP().execute();
 
       await prepExpectERC20BalancesChange(wBTC, alice.address);
 
@@ -267,7 +267,7 @@ describe("FHERC20ERC20Wrapper", function () {
       await hre.network.provider.send("evm_increaseTime", [11]);
       await hre.network.provider.send("evm_mine");
 
-      const decryption = await aliceClient.decryptForTx(ctHash).withoutPermit().execute();
+      const decryption = await aliceClient.decryptForTx(ctHash).withoutACP().execute();
 
       await prepExpectERC20BalancesChange(wBTC, alice.address);
 
@@ -301,8 +301,8 @@ describe("FHERC20ERC20Wrapper", function () {
       await hre.network.provider.send("evm_increaseTime", [11]);
       await hre.network.provider.send("evm_mine");
 
-      const dec1 = await bobClient.decryptForTx(request1.ctHash).withoutPermit().execute();
-      const dec2 = await bobClient.decryptForTx(request2.ctHash).withoutPermit().execute();
+      const dec1 = await bobClient.decryptForTx(request1.ctHash).withoutACP().execute();
+      const dec2 = await bobClient.decryptForTx(request2.ctHash).withoutACP().execute();
 
       await prepExpectERC20BalancesChange(wBTC, alice.address);
 
@@ -362,7 +362,7 @@ describe("FHERC20ERC20Wrapper", function () {
       await hre.network.provider.send("evm_increaseTime", [11]);
       await hre.network.provider.send("evm_mine");
 
-      const decryption = await bobClient.decryptForTx(ctHash).withoutPermit().execute();
+      const decryption = await bobClient.decryptForTx(ctHash).withoutACP().execute();
 
       await prepExpectERC20BalancesChange(wBTC, alice.address);
 
@@ -434,7 +434,7 @@ describe("FHERC20ERC20Wrapper", function () {
       await hre.network.provider.send("evm_increaseTime", [11]);
       await hre.network.provider.send("evm_mine");
 
-      const decryption = await bobClient.decryptForTx(ctHash).withoutPermit().execute();
+      const decryption = await bobClient.decryptForTx(ctHash).withoutACP().execute();
 
       // First claim succeeds
       await eBTC.connect(bob).claimUnshielded(claimId, decryption.decryptedValue, decryption.signature);

--- a/test/FHERC20NativeWrapper.test.ts
+++ b/test/FHERC20NativeWrapper.test.ts
@@ -274,7 +274,7 @@ describe("FHERC20NativeWrapper", function () {
       await hre.network.provider.send("evm_increaseTime", [11]);
       await hre.network.provider.send("evm_mine");
 
-      const decryption = await bobClient.decryptForTx(ctHash).withoutPermit().execute();
+      const decryption = await bobClient.decryptForTx(ctHash).withoutACP().execute();
 
       const aliceBalanceBefore = await ethers.provider.getBalance(alice.address);
 
@@ -317,7 +317,7 @@ describe("FHERC20NativeWrapper", function () {
       await hre.network.provider.send("evm_increaseTime", [11]);
       await hre.network.provider.send("evm_mine");
 
-      const decryption = await aliceClient.decryptForTx(ctHash).withoutPermit().execute();
+      const decryption = await aliceClient.decryptForTx(ctHash).withoutACP().execute();
 
       const aliceBalanceBefore = await ethers.provider.getBalance(alice.address);
 
@@ -352,8 +352,8 @@ describe("FHERC20NativeWrapper", function () {
       await hre.network.provider.send("evm_increaseTime", [11]);
       await hre.network.provider.send("evm_mine");
 
-      const dec1 = await bobClient.decryptForTx(request1.ctHash).withoutPermit().execute();
-      const dec2 = await bobClient.decryptForTx(request2.ctHash).withoutPermit().execute();
+      const dec1 = await bobClient.decryptForTx(request1.ctHash).withoutACP().execute();
+      const dec2 = await bobClient.decryptForTx(request2.ctHash).withoutACP().execute();
 
       const aliceBalanceBefore = await ethers.provider.getBalance(alice.address);
 
@@ -412,7 +412,7 @@ describe("FHERC20NativeWrapper", function () {
       await hre.network.provider.send("evm_increaseTime", [11]);
       await hre.network.provider.send("evm_mine");
 
-      const decryption = await bobClient.decryptForTx(ctHash).withoutPermit().execute();
+      const decryption = await bobClient.decryptForTx(ctHash).withoutACP().execute();
 
       const aliceBalanceBefore = await ethers.provider.getBalance(alice.address);
 
@@ -476,7 +476,7 @@ describe("FHERC20NativeWrapper", function () {
       await hre.network.provider.send("evm_increaseTime", [11]);
       await hre.network.provider.send("evm_mine");
 
-      const decryption = await bobClient.decryptForTx(ctHash).withoutPermit().execute();
+      const decryption = await bobClient.decryptForTx(ctHash).withoutACP().execute();
 
       // First claim succeeds
       await eETH.connect(bob).claimUnshielded(claimId, decryption.decryptedValue, decryption.signature);

--- a/test/FHERC20Reentrancy.test.ts
+++ b/test/FHERC20Reentrancy.test.ts
@@ -43,7 +43,10 @@ describe("FHERC20 *AndCall reentrancy (grok-audit-1 #1)", function () {
       const benign = (await (await ethers.getContractFactory("MockFHERC20Receiver")).deploy()) as MockFHERC20Receiver;
       const benignAddr = await benign.getAddress();
 
-      const [encInput] = await bobClient.encryptInputs([Encryptable.uint64(AMOUNT)]).execute();
+      const [encInput, encInputProof] = await bobClient
+        .encryptInputs([Encryptable.uint64(AMOUNT)])
+        .setConsumingContract(await token.getAddress())
+        .execute();
       await prepExpectFHERC20BalancesChange(token, bob.address);
       await prepExpectFHERC20BalancesChange(token, benignAddr);
 
@@ -51,7 +54,7 @@ describe("FHERC20 *AndCall reentrancy (grok-audit-1 #1)", function () {
       const callData = ethers.AbiCoder.defaultAbiCoder().encode(["uint8"], [0]);
       await token
         .connect(bob)
-        ["confidentialTransferAndCall(address,(uint256,uint8,uint8,bytes),bytes)"](benignAddr, encInput, callData);
+        ["confidentialTransferAndCall(address,bytes32,bytes,bytes)"](benignAddr, encInput, callData, encInputProof);
 
       await expectFHERC20BalancesChange(token, bob.address, 0n);
       await expectFHERC20BalancesChange(token, benignAddr, 0n);
@@ -64,7 +67,10 @@ describe("FHERC20 *AndCall reentrancy (grok-audit-1 #1)", function () {
       ).deploy(attacker.address)) as MaliciousReentrantReceiver;
       const evilAddr = await evil.getAddress();
 
-      const [encInput] = await bobClient.encryptInputs([Encryptable.uint64(AMOUNT)]).execute();
+      const [encInput, encInputProof] = await bobClient
+        .encryptInputs([Encryptable.uint64(AMOUNT)])
+        .setConsumingContract(await token.getAddress())
+        .execute();
       await prepExpectFHERC20BalancesChange(token, bob.address);
       await prepExpectFHERC20BalancesChange(token, attacker.address);
 
@@ -73,7 +79,7 @@ describe("FHERC20 *AndCall reentrancy (grok-audit-1 #1)", function () {
       await expect(
         token
           .connect(bob)
-          ["confidentialTransferAndCall(address,(uint256,uint8,uint8,bytes),bytes)"](evilAddr, encInput, "0x"),
+          ["confidentialTransferAndCall(address,bytes32,bytes,bytes)"](evilAddr, encInput, "0x", encInputProof),
       ).to.be.reverted;
 
       // Invariant regardless of how the fix is implemented: no theft.
@@ -118,14 +124,17 @@ describe("FHERC20 *AndCall reentrancy (grok-audit-1 #1)", function () {
       ).deploy(attacker.address)) as MaliciousUnshieldReceiver;
       const evilAddr = await evil.getAddress();
 
-      const [encInput] = await bobClient.encryptInputs([Encryptable.uint64(AMOUNT)]).execute();
+      const [encInput, encInputProof] = await bobClient
+        .encryptInputs([Encryptable.uint64(AMOUNT)])
+        .setConsumingContract(await wrapper.getAddress())
+        .execute();
       await prepExpectFHERC20BalancesChange(wrapper, bob.address);
 
       // The guard on unshield makes the re-entrant call revert -> whole AndCall reverts.
       await expect(
         wrapper
           .connect(bob)
-          ["confidentialTransferAndCall(address,(uint256,uint8,uint8,bytes),bytes)"](evilAddr, encInput, "0x"),
+          ["confidentialTransferAndCall(address,bytes32,bytes,bytes)"](evilAddr, encInput, "0x", encInputProof),
       ).to.be.reverted;
 
       // Sender not debited, and the attacker never obtained a pending claim on the underlying.

--- a/test/ReentrancyExploit.test.ts
+++ b/test/ReentrancyExploit.test.ts
@@ -47,7 +47,10 @@ describe("cross-function reentrancy in confidentialTransfer*AndCall", function (
     await benign.waitForDeployment();
     const benignAddr = await benign.getAddress();
 
-    const [encInput] = await bobClient.encryptInputs([Encryptable.uint64(TRANSFER_VALUE)]).execute();
+    const [encInput, encInputProof] = await bobClient
+      .encryptInputs([Encryptable.uint64(TRANSFER_VALUE)])
+      .setConsumingContract(await token.getAddress())
+      .execute();
 
     await prepExpectFHERC20BalancesChange(token, bob.address);
     await prepExpectFHERC20BalancesChange(token, benignAddr);
@@ -56,7 +59,7 @@ describe("cross-function reentrancy in confidentialTransfer*AndCall", function (
     const callData = ethers.AbiCoder.defaultAbiCoder().encode(["uint8"], [0]);
     await token
       .connect(bob)
-      ["confidentialTransferAndCall(address,(uint256,uint8,uint8,bytes),bytes)"](benignAddr, encInput, callData);
+      ["confidentialTransferAndCall(address,bytes32,bytes,bytes)"](benignAddr, encInput, callData, encInputProof);
 
     // The refund works as designed: nobody's balance moves.
     await expectFHERC20BalancesChange(token, bob.address, 0n);
@@ -75,7 +78,10 @@ describe("cross-function reentrancy in confidentialTransfer*AndCall", function (
     await evil.waitForDeployment();
     const evilAddr = await evil.getAddress();
 
-    const [encInput] = await bobClient.encryptInputs([Encryptable.uint64(TRANSFER_VALUE)]).execute();
+    const [encInput, encInputProof] = await bobClient
+      .encryptInputs([Encryptable.uint64(TRANSFER_VALUE)])
+      .setConsumingContract(await token.getAddress())
+      .execute();
 
     await prepExpectFHERC20BalancesChange(token, bob.address);
     await prepExpectFHERC20BalancesChange(token, attacker.address);
@@ -86,7 +92,7 @@ describe("cross-function reentrancy in confidentialTransfer*AndCall", function (
     try {
       await token
         .connect(bob)
-        ["confidentialTransferAndCall(address,(uint256,uint8,uint8,bytes),bytes)"](evilAddr, encInput, "0x");
+        ["confidentialTransferAndCall(address,bytes32,bytes,bytes)"](evilAddr, encInput, "0x", encInputProof);
     } catch {
       // A revert is an acceptable secure outcome (e.g. ReentrancyGuardReentrantCall).
     }

--- a/test/SyncSupplyOverflow.test.ts
+++ b/test/SyncSupplyOverflow.test.ts
@@ -74,7 +74,7 @@ describe("syncConfidentialTotalSupply pool-donation overflow (audit run-3 F9)", 
 
     await hre.network.provider.send("evm_increaseTime", [11]);
     await hre.network.provider.send("evm_mine");
-    const dec = await aliceClient.decryptForTx(claim.ctHash).withoutPermit().execute();
+    const dec = await aliceClient.decryptForTx(claim.ctHash).withoutACP().execute();
     await expect(h.connect(alice).claimUnshielded(claim.id, dec.decryptedValue, dec.signature)).to.not.be.reverted;
 
     // Alice is paid back the A she burned (rate 1), despite the over-ceiling pool balance.


### PR DESCRIPTION
`cofhe-contracts` 0.2.x deletes the `InEuintXX` structs and the `FHE.asEuint64(InEuint64)` overload. The per-ciphertext signature the struct carried is replaced by **one signature per batch**, passed as a trailing `bytes` parameter, and the verifier binds the consuming contract into the signed digest so a batch cannot be replayed into a different contract.

## Contracts

19 signatures move from `InEuint64 memory x` to `externalEuint64 x, bytes inputProof`:

| File | Signatures |
|---|---|
| `interfaces/IERC7984.sol` | 4 |
| `interfaces/IERC20ConfidentialCore.sol` | 2 |
| `FHERC20/FHERC20Core.sol` | 4 |
| `ERC20Confidential/ERC20ConfidentialCoreUpgradeable.sol` | 4 |
| `ERC20Confidential/ERC20ConfidentialLib.sol` | 4 |
| `test/MockFherc20Vault.sol` | 1 |

The proof is threaded through **13 consumption sites**: 9 `FHE.asEuint64` calls, plus 4 places where `ERC20ConfidentialCoreUpgradeable` forwards straight into the linked library rather than converting locally. `IFHERC20`'s now-unused `InEuint64` import is dropped.

## The one ABI decision to review

On the `*AndCall` overloads the proof goes **after** `bytes data`, not next to the amount:

```solidity
confidentialTransferAndCall(address to, externalEuint64 encryptedAmount, bytes calldata data, bytes calldata inputProof)
```

`@cofhe/abi` requires a plain `bytes` in the **final** parameter slot for the batch signature and rejects the ABI otherwise, so the natural `(to, amount, proof, data)` ordering is not available. I verified against the generated ABI that the proof is last on all four `*AndCall` variants, and that no arity collision appears with the `euint64` overloads — worth checking rather than assuming, since `euint64` and `externalEuint64` are both `bytes32` on the wire:

```
confidentialTransferAndCall(address, bytes32, bytes)          // euint64 overload
confidentialTransferAndCall(address, bytes32, bytes, bytes)   // external + proof
```

If you would rather have `(to, amount, proof, data)` for readability, say so and I will change it, but the TypeScript helpers will then reject the ABI.

## Redeploy required

`ERC20ConfidentialLib`'s ABI changed, so this build is **not interchangeable** with library instances deployed before 0.7. It must be redeployed and every host relinked. The `hardhat.config.ts` note that previously claimed byte-identical executable code against already-deployed instances is corrected accordingly; the `0.8.26` / `runs: 1` / `cancun` pin is retained so this version is itself reproducible. Library is 11,206 bytes, 13.4KB under EIP-170.

## Tests

**237 passing, 0 failing.** Same count as before the migration, so no coverage was lost.

| Change | Count |
|---|---|
| `encryptInputs` sites now calling `.setConsumingContract(...)` and destructuring `[hash, signature]` | 33 |
| Argument lists carrying the proof | 41 |
| Overload selector strings reshaped from `(uint256,uint8,uint8,bytes)` to `bytes32,bytes` | 44 |
| `.withoutPermit()` renamed to `.withoutACP()` | 25 |

Two suites build their encrypted input inside a `setup*Fixture()` and destructure it across five `it` blocks each, so the fixture return and its destructures thread the proof as well. Worth a glance during review: a naive rewrite appends the proof to any call mentioning the variable, which would have corrupted those `return { … }` and `const { … } =` statements.

## Version pinning

Pinned to `@fhenixprotocol/cofhe-contracts@0.2.0-beta.3` and `@cofhe/*@0.0.0-alpha-20260818094925`, because 0.7.0 is not on the registry yet. **This package is published**, so merging propagates those prereleases to every downstream consumer — worth holding the release until stable versions land, even if the code merges sooner.

## Not included

Moving encrypted values that cross a **contract boundary** onto the `sharedEuintXX` types. That changes `IERC7984Receiver`, which third parties implement, and both sides of a handoff must migrate together, so it needs to track the ERC-7984 direction. The old spelling still compiles and runs, which means **a passing suite is not evidence that pass is done**. The tooling is now in place to prototype it: `shareEbool`, `receiveEboolFromCall` and the mock share slots all exist in this alpha.

Also unchanged: `prettier --check` and `tsc` still report pre-existing issues in `scripts/` and a few untouched contract files. Formatting here was scoped to only the files this migration touches, to keep the diff free of unrelated churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




