### PR TITLE
feat: move the transfer-callback boundary onto sharedEuintXX

### DIFF
--- a/.changeset/shy-receivers-share.md
+++ b/.changeset/shy-receivers-share.md
@@ -1,0 +1,17 @@
+---
+"fhenix-confidential-contracts": major
+---
+
+Move the transfer-callback boundary onto the `sharedEuintXX` types.
+
+`IERC7984Receiver.onConfidentialTransferReceived` previously took a bare `euint64` and returned a bare `ebool`, with permission granted out of band via `FHE.allowTransient`. On a callback that cannot authenticate its caller, that is a decryption oracle: FHE operations check the permission of the *contract* performing them, so any caller could pass any handle the receiver is allowed on (including the receiver's own stored state) and read back a value derived from it.
+
+Breaking change:
+
+- **`IERC7984Receiver.onConfidentialTransferReceived` now takes `sharedEuint64` and returns `sharedEbool`.** Both are `bytes32` on the wire, so existing receivers keep compiling against the old signature and fail at runtime with `NotShared`. Every receiver must migrate in the same change.
+
+Implementers must unwrap the amount with `FHE.receiveEuint64Param(amount)`, which requires the sharer to be `msg.sender`, and return `FHE.shareEbool(result, msg.sender)` instead of granting the token access with `FHE.allowTransient`. A received handle carries transient access only; persisting it past the transaction requires `FHE.allowThis` on the unwrapped `euint64`.
+
+`FHERC20Utils.checkOnTransferReceived` still returns a plain `ebool`, so callers inside the token are unaffected.
+
+The ERC-7984 user-facing entry points (`confidentialTransfer(address,euint64)` and friends) deliberately keep accepting bare handles: an EOA cannot create a share, so converting them would make the standard's API unusable from a wallet, and they are already guarded by `FHE.isAllowed(value, msg.sender)`, which prevents a caller naming a handle they do not themselves hold.

--- a/contracts/FHERC20/utils/FHERC20Utils.sol
+++ b/contracts/FHERC20/utils/FHERC20Utils.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { FHE, ebool, euint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+import { FHE, ebool, euint64, sharedEbool } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
 
 import { IERC7984Receiver } from "../../interfaces/IERC7984Receiver.sol";
 import { FHERC20InvalidReceiver } from "./FHERC20Errors.sol";
@@ -14,9 +14,14 @@ library FHERC20Utils {
      *
      * The transfer callback is not invoked on the recipient if the recipient has no code (i.e. is an EOA). If the
      * recipient has non-zero code, it must implement
-     * {IERC7984Receiver-onConfidentialTransferReceived} and return an `ebool` indicating
-     * whether the transfer was accepted or not. If the `ebool` is `false`, the transfer function
-     * should try to refund the `from` address.
+     * {IERC7984Receiver-onConfidentialTransferReceived} and return a `sharedEbool` indicating
+     * whether the transfer was accepted or not. If the decoded `ebool` is `false`, the transfer
+     * function should try to refund the `from` address.
+     *
+     * Both encrypted values crossing this boundary are directed shares (see {IERC7984Receiver}):
+     * `amount` is shared to `to`, and the returned flag is consumed with
+     * `receiveEboolFromCall(_, to)` so that only a value `to` itself handed back is accepted.
+     * Returns a plain `ebool` so callers are unaffected by the boundary's typing.
      */
     function checkOnTransferReceived(
         address operator,
@@ -26,10 +31,16 @@ library FHERC20Utils {
         bytes calldata data
     ) internal returns (ebool) {
         if (to.code.length > 0) {
-            try IERC7984Receiver(to).onConfidentialTransferReceived(operator, from, amount, data) returns (
-                ebool retval
-            ) {
-                return retval;
+            // `shareEuint64` grants `to` transient access itself and records this contract as the
+            // sharer, so no separate `allowTransient` is needed. It reverts `SenderNotAllowed` if
+            // we do not hold `amount`: you cannot share what you cannot use.
+            try
+                IERC7984Receiver(to).onConfidentialTransferReceived(operator, from, FHE.shareEuint64(amount, to), data)
+            returns (sharedEbool retval) {
+                // `to` is the address called immediately above, which is what makes this the
+                // correct receive form: it checks who HANDED the value over, not merely who
+                // created the share. Naming any other address would be exploitable.
+                return FHE.receiveEboolFromCall(retval, to);
             } catch (bytes memory reason) {
                 if (reason.length == 0) {
                     revert FHERC20InvalidReceiver(to);
@@ -40,6 +51,7 @@ library FHERC20Utils {
                 }
             }
         } else {
+            // No callback to make, so nothing was shared and there is nothing to receive.
             return FHE.asEbool(true);
         }
     }

--- a/contracts/interfaces/IERC7984Receiver.sol
+++ b/contracts/interfaces/IERC7984Receiver.sol
@@ -1,9 +1,26 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import {ebool, euint64} from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+import { sharedEbool, sharedEuint64 } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
 
 /// @dev Interface for contracts that can receive FHERC20 transfers with a callback.
+///
+/// Both encrypted values on this boundary use the `sharedXX` types, because this is a
+/// contract-to-contract handoff on a function that cannot authenticate its caller. A bare
+/// `euint64` parameter here would be a decryption oracle: FHE operations check the permission of
+/// the contract performing them, so any caller could pass any handle THIS contract is allowed on
+/// (including its own stored state) and read back a value derived from it. `sharedEuint64` closes
+/// that by recording who shared the value, for this transaction only, directed at this contract by
+/// name.
+///
+/// Implementers must therefore:
+///   - unwrap the amount with `FHE.receiveEuint64Param(amount)`, which requires the sharer to be
+///     `msg.sender` (the token) and reverts `NotShared` / `UnexpectedSharer` otherwise; and
+///   - return `FHE.shareEbool(result, msg.sender)` rather than granting the token access out of
+///     band with `FHE.allowTransient`.
+///
+/// The received handle carries transient access only. To keep the amount past this transaction,
+/// call `FHE.allowThis` on the unwrapped `euint64`, not on the `sharedEuint64`.
 interface IERC7984Receiver {
     /**
      * @dev Called upon receiving a confidential token transfer. Returns an encrypted boolean indicating success
@@ -14,7 +31,7 @@ interface IERC7984Receiver {
     function onConfidentialTransferReceived(
         address operator,
         address from,
-        euint64 amount,
+        sharedEuint64 amount,
         bytes calldata data
-    ) external returns (ebool);
+    ) external returns (sharedEbool);
 }

--- a/contracts/test/MaliciousReentrantReceiver.sol
+++ b/contracts/test/MaliciousReentrantReceiver.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.25;
 
 import { IERC7984Receiver } from "../interfaces/IERC7984Receiver.sol";
 import { IERC20ConfidentialCore } from "../interfaces/IERC20ConfidentialCore.sol";
-import { ebool, euint64, FHE } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+import { ebool, euint64, sharedEbool, sharedEuint64, FHE } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
 
 /**
  * @dev Test-only attacker that triggers a cross-function reentrancy in
@@ -31,9 +31,12 @@ contract MaliciousReentrantReceiver is IERC7984Receiver {
     function onConfidentialTransferReceived(
         address /* operator */,
         address /* from */,
-        euint64 amount,
+        sharedEuint64 sharedAmount,
         bytes calldata /* data */
-    ) external returns (ebool) {
+    ) external returns (sharedEbool) {
+        // Unwrap the directed share. Requires the sharer to be `msg.sender` (the token), so an
+        // arbitrary caller cannot reach this callback with a handle nobody shared.
+        euint64 amount = FHE.receiveEuint64Param(sharedAmount);
         // `msg.sender` is the token. The forward leg of `_moveAndCall` already
         // credited us `amount` and granted us ACL on this handle (update() line
         // 109), so we can spend it right now — before the refund leg runs.
@@ -48,7 +51,6 @@ contract MaliciousReentrantReceiver is IERC7984Receiver {
         // debit us `amount`, but our balance is now 0, so tryDecrease saturates to
         // a no-op and the sender is never made whole.
         ebool rejected = FHE.asEbool(false);
-        FHE.allowTransient(rejected, msg.sender);
-        return rejected;
+        return FHE.shareEbool(rejected, msg.sender);
     }
 }

--- a/contracts/test/MaliciousUnshieldReceiver.sol
+++ b/contracts/test/MaliciousUnshieldReceiver.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.25;
 
 import { IERC7984Receiver } from "../interfaces/IERC7984Receiver.sol";
-import { ebool, euint64, FHE } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+import { ebool, euint64, sharedEbool, sharedEuint64, FHE } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
 
 /// @dev The wrapper's `unshield` overload this attacker re-enters.
 interface IReentrantUnshield {
@@ -32,9 +32,12 @@ contract MaliciousUnshieldReceiver is IERC7984Receiver {
     function onConfidentialTransferReceived(
         address /* operator */,
         address /* from */,
-        euint64 amount,
+        sharedEuint64 sharedAmount,
         bytes calldata /* data */
-    ) external returns (ebool) {
+    ) external returns (sharedEbool) {
+        // Unwrap the directed share. Requires the sharer to be `msg.sender` (the token), so an
+        // arbitrary caller cannot reach this callback with a handle nobody shared.
+        euint64 amount = FHE.receiveEuint64Param(sharedAmount);
         // The forward leg already credited us `amount` and granted us ACL on the
         // handle, so we can unshield it right now — before the refund leg runs.
         if (!reentered) {
@@ -43,7 +46,6 @@ contract MaliciousUnshieldReceiver is IERC7984Receiver {
         }
 
         ebool rejected = FHE.asEbool(false);
-        FHE.allowTransient(rejected, msg.sender);
-        return rejected;
+        return FHE.shareEbool(rejected, msg.sender);
     }
 }

--- a/contracts/test/MockFHERC20Receiver.sol
+++ b/contracts/test/MockFHERC20Receiver.sol
@@ -2,14 +2,21 @@
 pragma solidity ^0.8.25;
 
 import { IERC7984Receiver } from "../interfaces/IERC7984Receiver.sol";
-import { ebool, euint64, FHE } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+import { ebool, sharedEbool, sharedEuint64, FHE } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
 
 contract MockFHERC20Receiver is IERC7984Receiver {
     event ConfidentialTransferCallback(bool success);
 
     error InvalidInput(uint8 input);
 
-    function onConfidentialTransferReceived(address, address, euint64, bytes calldata data) external returns (ebool) {
+    /// @dev Decides purely on `data`, so it never unwraps the shared amount; that share simply
+    ///      expires at the end of the transaction.
+    function onConfidentialTransferReceived(
+        address,
+        address,
+        sharedEuint64,
+        bytes calldata data
+    ) external returns (sharedEbool) {
         uint8 input = abi.decode(data, (uint8));
 
         if (input > 1) revert InvalidInput(input);
@@ -18,8 +25,8 @@ contract MockFHERC20Receiver is IERC7984Receiver {
         emit ConfidentialTransferCallback(success);
 
         ebool returnVal = FHE.asEbool(success);
-        FHE.allowTransient(returnVal, msg.sender);
 
-        return returnVal;
+        // Directed back at the token that called us, instead of an out-of-band grant.
+        return FHE.shareEbool(returnVal, msg.sender);
     }
 }

--- a/contracts/test/SharedAmountReceiver.sol
+++ b/contracts/test/SharedAmountReceiver.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { IERC7984Receiver } from "../interfaces/IERC7984Receiver.sol";
+import { ebool, euint64, sharedEbool, sharedEuint64, FHE } from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+
+/// @notice Minimal well-behaved receiver that actually CONSUMES the shared amount, so the
+///         share/receive round trip can be asserted end to end.
+///
+///         {MockFHERC20Receiver} decides purely on `data` and never unwraps the amount, and the two
+///         malicious receivers re-enter the token as a side effect. This one just records what it
+///         received, which makes it usable for two assertions the other three cannot support:
+///
+///           1. the legitimate path delivers the real transferred amount to the receiver; and
+///           2. an arbitrary caller invoking this callback directly with a handle nobody shared
+///              reverts, instead of getting an FHE operation performed on it.
+contract SharedAmountReceiver is IERC7984Receiver {
+    /// @notice The amount handle unwrapped from the last callback, persisted for inspection.
+    euint64 public lastAmount;
+    uint256 public callbackCount;
+
+    function onConfidentialTransferReceived(
+        address,
+        address,
+        sharedEuint64 sharedAmount,
+        bytes calldata
+    ) external returns (sharedEbool) {
+        // Reverts unless `msg.sender` is the recorded sharer AND still holds the handle.
+        euint64 amount = FHE.receiveEuint64Param(sharedAmount);
+
+        // A received handle carries transient access only, so persisting it past this
+        // transaction requires allowThis on the UNWRAPPED value.
+        FHE.allowThis(amount);
+        FHE.allowPublic(amount);
+        lastAmount = amount;
+        callbackCount += 1;
+
+        ebool accepted = FHE.asEbool(true);
+        return FHE.shareEbool(accepted, msg.sender);
+    }
+}

--- a/test/SharedEuintBoundary.test.ts
+++ b/test/SharedEuintBoundary.test.ts
@@ -1,0 +1,79 @@
+import { expect } from "chai";
+import hre, { ethers } from "hardhat";
+import { Encryptable } from "@cofhe/sdk";
+import { FHERC20_Harness, SharedAmountReceiver } from "../typechain-types";
+
+// Proves the `sharedEuintXX` migration of the transfer-callback boundary actually bought the
+// protection it is supposed to, rather than just changing types.
+//
+// The boundary is FHERC20Utils.checkOnTransferReceived ->
+// IERC7984Receiver.onConfidentialTransferReceived. Before the migration both encrypted values on
+// that boundary were bare handles with an out-of-band `allowTransient` grant, which makes an
+// unauthenticated callback into a decryption oracle: FHE operations check the permission of the
+// CONTRACT performing them, so any caller could pass any handle the receiver is allowed on and
+// read back a value derived from it.
+//
+// A clean compile proves nothing here (the old spelling compiled too), and neither does the
+// existing *AndCall suite, which only walks the happy path. These two cases are the actual
+// evidence: the round trip delivers the real value, and the direct-call oracle path is closed.
+const AMOUNT = BigInt(1e6); // 1.0 confidential unit at 6 decimals
+
+describe("sharedEuint64 transfer-callback boundary", function () {
+  async function fixture() {
+    const [, bob] = await ethers.getSigners();
+    // FHERC20 base does not use the claims lib — no linking needed.
+    const token = (await (
+      await ethers.getContractFactory("FHERC20_Harness")
+    ).deploy("Confidential Token", "CTK", 6, "")) as FHERC20_Harness;
+    await token.waitForDeployment();
+    await (await token.mint(bob.address, 10n * AMOUNT)).wait();
+
+    const receiver = (await (await ethers.getContractFactory("SharedAmountReceiver")).deploy()) as SharedAmountReceiver;
+    await receiver.waitForDeployment();
+
+    const bobClient = await hre.cofhe.createClientWithBatteries(bob);
+    return { bob, token, receiver, bobClient };
+  }
+
+  it("round trip: the receiver really receives the transferred amount", async function () {
+    const { bob, token, receiver, bobClient } = await fixture();
+    const receiverAddr = await receiver.getAddress();
+
+    const [hash, proof] = await bobClient
+      .encryptInputs([Encryptable.uint64(AMOUNT)])
+      .setConsumingContract(await token.getAddress())
+      .execute();
+
+    await (
+      await token
+        .connect(bob)
+        ["confidentialTransferAndCall(address,bytes32,bytes,bytes)"](receiverAddr, hash, "0x", proof)
+    ).wait();
+
+    // The callback ran, unwrapped the directed share, and persisted the handle.
+    expect(await receiver.callbackCount()).to.equal(1n);
+    // And what it unwrapped is the real transferred amount, not a zero or a stray handle.
+    await hre.cofhe.mocks.expectPlaintext(await receiver.lastAmount(), AMOUNT);
+  });
+
+  it("oracle path is closed: calling the callback directly with an unshared handle reverts", async function () {
+    const { bob, token, receiver } = await fixture();
+
+    // A handle the RECEIVER is legitimately allowed on would be the strongest input, but any
+    // handle demonstrates the check: nothing was shared with the receiver in this transaction,
+    // so `receiveEuint64Param` has no share record to consume and must refuse. Before the
+    // migration this call succeeded and performed FHE work on the attacker's chosen handle.
+    const someHandle = await token.confidentialBalanceOf(bob.address);
+
+    // Assert the SPECIFIC refusal, not just "it reverted": NotShared is the ACL reporting that
+    // no share record exists for this receiver. A generic `to.be.reverted` would also pass on an
+    // unrelated failure and would not prove the oracle path is what closed.
+    const aclAbi = await ethers.getContractAt("MockACL", ethers.ZeroAddress);
+    await expect(
+      receiver.connect(bob).onConfidentialTransferReceived(bob.address, bob.address, someHandle, "0x"),
+    ).to.be.revertedWithCustomError(aclAbi, "NotShared");
+
+    // No callback was recorded, so the receiver did no FHE work on the supplied handle.
+    expect(await receiver.callbackCount()).to.equal(0n);
+  });
+});


### PR DESCRIPTION
Closes the decryption-oracle path on the transfer-callback boundary by moving both of its encrypted values onto the `sharedEuintXX` types.

## Why this is security work, not a type change

`IERC7984Receiver.onConfidentialTransferReceived` took a bare `euint64` and returned a bare `ebool`, with permission granted out of band through `FHE.allowTransient`. On a callback that **cannot authenticate its caller**, that is a decryption oracle.

FHE operations check the permission of the *contract* performing them, not of whoever called it. So any caller could invoke a receiver's callback with **any handle that receiver is allowed on** — including the receiver's own stored state, since handles are plain `bytes32` readable from storage, events, or a getter — and read back a value derived from it. A bare handle carries no provenance: the receiver can see it is permitted to use a ciphertext, but not who handed it over, or whether it was handed over at all.

`sharedEuint64` closes this with a directed, single-use, transaction-scoped share slot: the share records the sharer, and `receive` requires that sharer to be who the receiver names.

## Changes

| File | Change |
|---|---|
| `interfaces/IERC7984Receiver.sol` | Takes `sharedEuint64`, returns `sharedEbool`. Implementer contract carries the rationale and the persistence caveat |
| `FHERC20/utils/FHERC20Utils.sol` | Shares the amount to `to` inside the `try` expression; consumes the reply with `receiveEboolFromCall(retval, to)`. Still returns a plain `ebool`, so callers inside the token are unchanged |
| `test/MockFHERC20Receiver.sol` | Returns `FHE.shareEbool(...)` instead of a bare `allowTransient` grant |
| `test/MaliciousReentrantReceiver.sol`, `test/MaliciousUnshieldReceiver.sol` | Unwrap with `receiveEuint64Param`, return with `shareEbool`. Both still re-enter successfully, so they remain real attack tests rather than being neutered by the ACL |
| `test/SharedAmountReceiver.sol` | **New.** A receiver that genuinely consumes the amount, so the round trip can be asserted |
| `test/SharedEuintBoundary.test.ts` | **New.** The two cases below |

`receiveEboolFromCall(retval, to)` names `to`, the address actually called on that line. That is the distinction that matters: naming a merely-trusted address would check who *created* the share rather than who *handed it over*, which is exploitable via a share left unconsumed earlier in the transaction.

## The old spelling still compiles, so I proved it instead of assuming it

A clean build is not evidence here, and the pre-existing `*AndCall` suite only walks the happy path. Two new cases are the actual evidence:

1. **Round trip** — the receiver unwraps the share and `expectPlaintext` confirms it received the *real* transferred amount, not a zero or a stray handle.
2. **Oracle path closed** — invoking the callback directly with a handle nobody shared reverts with **`NotShared`**.

On (2), the assertion pins that specific error rather than using a bare `to.be.reverted`, which would also pass on an unrelated failure and would prove nothing about the oracle. I decoded the revert to confirm it is the ACL's share check refusing, not an incidental failure. `NotShared` is declared by the ACL rather than by our contracts, so the matcher is handed the ACL's ABI.

**239 passing, 0 failing.**

## Scope: the ERC-7984 entry points keep bare handles

`confidentialTransfer(address,euint64)` and friends are deliberately **not** converted, and this is not a coordination decision:

- **An EOA cannot create a share.** Converting the input side would make the standard's user-facing API unusable from a wallet.
- The cofhe guidance keeps values arriving from a user on `euintXX`.
- They are already guarded by `FHE.isAllowed(value, msg.sender)`, so a caller cannot name a handle they do not themselves hold. That is what makes them not oracles.

## Bare-handle audit

All 21 externally-reachable sites taking a bare `euint64` were audited programmatically. Nine looked unguarded; all nine are accounted for:

- **5** core entry points delegate to guarded library functions one level down (`confidentialTransfer` → `confTransfer`, `unshield(euint64)` → `unshieldChecked`).
- **3** (`update`, `createClaim`, raw `unshield`) are `public` only so the library can be `delegatecall`ed. No host exposes them, and called directly at the library address they execute in the library's own context, which holds no state and no ACL grants.
- **1** (`discloseEncryptedAmount`) is authenticated by `FHE.verifyDecryptResult` rather than by ACL, and reveals only what is already publicly decryptable.

## Left open deliberately

The remaining `FHE.allowTransient` sites are the S2 return-value pattern on those same user-facing functions (returning `euint64` from a non-view function and granting it to `msg.sender`). Converting them is coupled to the input side, so it is the same standards question, and it changes the ERC-7984 return type. Worth deciding explicitly rather than having it arrive as a side effect of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



